### PR TITLE
支持桌宠客户端

### DIFF
--- a/.dsh-plugin/client.js
+++ b/.dsh-plugin/client.js
@@ -180,6 +180,7 @@ var INTERACT_PATH = `${ROUTE_PREFIX}/interact`;
 var CONFIG_PATH = `${ROUTE_PREFIX}/config`;
 var ASSETS_PATH = `${ROUTE_PREFIX}/assets`;
 var EVENTS_PATH = `${ROUTE_PREFIX}/events`;
+var PRESENCE_PATH = `${ROUTE_PREFIX}/presence`;
 
 // .dsh-plugin/client/index.mjs
 var ASSETS_URL = ASSETS_PATH;
@@ -959,6 +960,11 @@ function apply(ctx = {}) {
         const config = await fetchConfig();
         if (config !== null) applyClientConfig(config);
       }
+      const nextCompanion = body?.companionOnline === true;
+      if (nextCompanion !== companionOnline) {
+        companionOnline = nextCompanion;
+        syncInert();
+      }
       failStreak = 0;
       renderStatus();
     } catch {
@@ -1207,13 +1213,14 @@ function apply(ctx = {}) {
   };
   window.addEventListener("resize", onResize);
   let pageHidden = false;
+  let companionOnline = false;
   const syncInert = () => {
     const dialog = document.querySelector('[role="dialog"]') !== null;
     const onboarding = document.getElementById("deepseek-onboarding-title") !== null || document.querySelector('[aria-labelledby="deepseek-onboarding-title"]') !== null;
-    const next = onboarding ? "onboarding" : dialog ? "dialog" : null;
+    const next = onboarding ? "onboarding" : companionOnline ? "companion" : dialog ? "dialog" : null;
     if (next !== pageHidden) {
       pageHidden = next;
-      if (next === "onboarding") {
+      if (next === "onboarding" || next === "companion") {
         host.setAttribute("data-whale-girl-hidden", "");
         host.removeAttribute("data-whale-girl-inert");
         host.style.display = "none";

--- a/.dsh-plugin/client.js
+++ b/.dsh-plugin/client.js
@@ -185,6 +185,7 @@ var EVENTS_PATH = `${ROUTE_PREFIX}/events`;
 var ASSETS_URL = ASSETS_PATH;
 var MANIFEST_URL = `${ASSETS_URL}/manifest.json`;
 var CFG_DEFAULTS = {
+  enabled: true,
   size: 110,
   opacity: 1,
   walk: { enabled: true, minWaitMs: 18e3, maxWaitMs: 4e4, minMs: 3e3, maxMs: 6e3, speedPxPerSec: 45 },
@@ -347,6 +348,7 @@ function apply(ctx = {}) {
     width: var(--pet-size, 110px); height: var(--pet-size, 110px);
     font-family: system-ui, sans-serif; user-select: none; touch-action: none;
     opacity: var(--pet-opacity, 1);`;
+  host.style.display = "none";
   document.body.appendChild(host);
   const stage = document.createElement("div");
   stage.className = "pet-stage";
@@ -896,6 +898,10 @@ function apply(ctx = {}) {
   };
   const applyClientConfig = (config) => {
     if (config === null || typeof config !== "object") return;
+    if (config.enabled === false) {
+      dispose();
+      return;
+    }
     const prevPollMs = cfg.pollMs;
     cfg = { ...CFG_DEFAULTS, ...config };
     if (typeof config.size === "number") {
@@ -1163,17 +1169,29 @@ function apply(ctx = {}) {
       armWorking();
     }, delay);
   };
-  loadAssets();
-  refresh();
-  pollTimer = setInterval(refresh, cfg.pollMs);
-  const animTimer = setInterval(tick, TICK_MS);
-  scheduleWander();
-  armWorking();
-  try {
-    const sse = new EventSource(EVENTS_PATH);
-    sse.onmessage = () => refresh();
-  } catch {
-  }
+  let animTimer = null;
+  let sse = null;
+  const boot = async () => {
+    const config = await fetchConfig();
+    if (config !== null && config.enabled === false) {
+      dispose();
+      return;
+    }
+    if (config !== null) applyClientConfig(config);
+    host.style.display = "";
+    loadAssets();
+    refresh();
+    pollTimer = setInterval(refresh, cfg.pollMs);
+    animTimer = setInterval(tick, TICK_MS);
+    scheduleWander();
+    armWorking();
+    try {
+      sse = new EventSource(EVENTS_PATH);
+      sse.onmessage = () => refresh();
+    } catch {
+    }
+  };
+  boot();
   armWorking();
   const onVisibility = () => {
     if (document.visibilityState === "visible") refresh();
@@ -1216,9 +1234,10 @@ function apply(ctx = {}) {
   const dialogObserver = new MutationObserver(syncInert);
   dialogObserver.observe(document.body, { childList: true, subtree: true });
   syncInert();
-  return () => {
+  const dispose = () => {
     clearInterval(pollTimer);
-    clearInterval(animTimer);
+    if (animTimer !== null) clearInterval(animTimer);
+    if (sse !== null) sse.close();
     clearTimeout(wanderTimer);
     if (workingTimer !== null) clearTimeout(workingTimer);
     if (walkRaf !== null) cancelAnimationFrame(walkRaf);
@@ -1238,6 +1257,7 @@ function apply(ctx = {}) {
     host.remove();
     style.remove();
   };
+  return dispose;
 }
 var name = "whale-girl";
 		return module.exports;

--- a/.dsh-plugin/client.js
+++ b/.dsh-plugin/client.js
@@ -29,11 +29,13 @@ __export(index_exports, {
 });
 module.exports = __toCommonJS(index_exports);
 
+// .dsh-plugin/src/snapshot.mjs
+var TURN_COMPLETED_MS = 4e3;
+
 // .dsh-plugin/client/logic.mjs
 var TRANSIENT_MS = 1500;
 var WAKE_MS = 3e3;
 var JOY_MS = 1600;
-var ROUND_CELEBRATE_MS = 4e3;
 var STATE_NAMES = Object.freeze([
   "idle",
   "working",
@@ -932,8 +934,10 @@ function apply(ctx = {}) {
           waiting: act.sessionWait === true,
           titles: []
         };
-        if (act.turnCompleted === true) {
-          celebrateUntil = Date.now() + ROUND_CELEBRATE_MS;
+        if (Number.isFinite(act.turnCompletedUntil) && act.turnCompletedUntil > Date.now()) {
+          celebrateUntil = Math.max(celebrateUntil, act.turnCompletedUntil);
+        } else if (act.turnCompleted === true) {
+          celebrateUntil = Math.max(celebrateUntil, Date.now() + TURN_COMPLETED_MS);
         }
         armWorking();
       }

--- a/.dsh-plugin/client/index.mjs
+++ b/.dsh-plugin/client/index.mjs
@@ -964,6 +964,13 @@ export function apply(ctx = {}) {
         const config = await fetchConfig()
         if (config !== null) applyClientConfig(config)
       }
+      // 桌面伴侣在场（/state companionOnline，心跳窗口）：在场期间隐藏网页端宠物，
+      // 避免与桌面端双宠物；下线（心跳过期）后自动恢复显示。
+      const nextCompanion = body?.companionOnline === true
+      if (nextCompanion !== companionOnline) {
+        companionOnline = nextCompanion
+        syncInert()
+      }
       // 睡醒过渡由 tick 视觉边沿触发（animState 离开 sleep 的瞬间播 wake）——见 tick 注释，
       // 不在这里判定（旧逻辑基于 sleeping 变量，会话活跃时永不翻转，见决策记录）。
       failStreak = 0
@@ -1274,19 +1281,21 @@ export function apply(ctx = {}) {
   }
   window.addEventListener('resize', onResize)
 
-  // 页面状态感知：DSH onboarding 向导激活时宠物隐藏（display:none，不挡向导）；
-  // dialog 打开时降为 inert（半透明、不挡点击）。
+  // 页面状态感知：DSH onboarding 向导激活或桌面伴侣在场时宠物隐藏（display:none，
+  // 不挡向导 / 避免双宠物）；dialog 打开时降为 inert（半透明、不挡点击）。
   // onboarding 判定：deepseek-onboarding-title（DSH 向导页面标题，精确标识——
   // 不用宽泛的 [class*="onboarding"] 子串，避免误伤类名含 onboarding 的其它元素）。
+  // companionOnline：/state 下发的桌面伴侣在场窗口（心跳过期自动恢复显示）。
   let pageHidden = false
+  let companionOnline = false
   const syncInert = () => {
     const dialog = document.querySelector('[role="dialog"]') !== null
     const onboarding = document.getElementById('deepseek-onboarding-title') !== null
       || document.querySelector('[aria-labelledby="deepseek-onboarding-title"]') !== null
-    const next = onboarding ? 'onboarding' : dialog ? 'dialog' : null
+    const next = onboarding ? 'onboarding' : companionOnline ? 'companion' : dialog ? 'dialog' : null
     if (next !== pageHidden) {
       pageHidden = next
-      if (next === 'onboarding') {
+      if (next === 'onboarding' || next === 'companion') {
         host.setAttribute('data-whale-girl-hidden', '')
         host.removeAttribute('data-whale-girl-inert')
         // 内联是权威（CSS 规则可能被宿主清理——属性设了但视觉不变）。

--- a/.dsh-plugin/client/index.mjs
+++ b/.dsh-plugin/client/index.mjs
@@ -925,16 +925,18 @@ export function apply(ctx = {}) {
       if (act !== null && typeof act === 'object' && typeof act.name === 'string') {
         activity = act
       }
-      // 会话感知（v8）：Node half 把 sessionThink/sessionWait/turnCompleted 聚合进 /state——
-      // 自渲染 client 无 ctx.sessions，改从轮询读。turnCompleted 单轮翻转 → 播回合完成庆祝。
+      // 会话感知：Node half 把 sessionThink/sessionWait/回合完成窗口聚合进 /state。
+      // 绝对截止时间允许 Web 与外部伴侣同时读取；boolean 仅兼容旧版 Node half。
       if (act !== null && typeof act === 'object') {
         sessionMood = {
           thinking: act.sessionThink === true,
           waiting: act.sessionWait === true,
           titles: [],
         }
-        if (act.turnCompleted === true) {
-          celebrateUntil = Date.now() + ROUND_CELEBRATE_MS
+        if (Number.isFinite(act.turnCompletedUntil) && act.turnCompletedUntil > Date.now()) {
+          celebrateUntil = Math.max(celebrateUntil, act.turnCompletedUntil)
+        } else if (act.turnCompleted === true) {
+          celebrateUntil = Math.max(celebrateUntil, Date.now() + ROUND_CELEBRATE_MS)
         }
         armWorking() // 会话活跃状态变化 → 重排 working 插曲（思考开始武装/结束撤防）
       }

--- a/.dsh-plugin/client/index.mjs
+++ b/.dsh-plugin/client/index.mjs
@@ -21,7 +21,7 @@ const MANIFEST_URL = `${ASSETS_URL}/manifest.json`
 // 消费端不写第二份默认值，见 verify-config-sync 门禁）。/state 的 configRevision
 // 变化时拉取新值（applyClientConfig），未配置时用默认值。
 const CFG_DEFAULTS = {
-  size: 110, opacity: 1,
+  enabled: true, size: 110, opacity: 1,
   walk: { enabled: true, minWaitMs: 18000, maxWaitMs: 40000, minMs: 3000, maxMs: 6000, speedPxPerSec: 45 },
   sleepAfterMs: 60000, pollMs: 3000, bubbleMs: 2500,
 }
@@ -195,6 +195,8 @@ export function apply(ctx = {}) {
     width: var(--pet-size, 110px); height: var(--pet-size, 110px);
     font-family: system-ui, sans-serif; user-select: none; touch-action: none;
     opacity: var(--pet-opacity, 1);`
+  // enabled 门控引导：先隐藏挂载（不闪一下再消失），boot 取配置判定渲染开关后再显示。
+  host.style.display = 'none'
   document.body.appendChild(host)
 
   const stage = document.createElement('div')
@@ -890,6 +892,12 @@ export function apply(ctx = {}) {
   // 应用客户端配置：尺寸/透明度走 CSS 变量；游走/睡眠/轮询参数更新 cfg（下次行为生效）。
   const applyClientConfig = (config) => {
     if (config === null || typeof config !== 'object') return
+    // 网页端渲染开关：热切换为 false 立即卸载（桌面伴侣并存时避免双宠物）。
+    // 重新启用需刷新页面（client 自渲染无重建路径）；undefined 视为启用（向后兼容）。
+    if (config.enabled === false) {
+      dispose()
+      return
+    }
     const prevPollMs = cfg.pollMs
     cfg = { ...CFG_DEFAULTS, ...config }
     if (typeof config.size === 'number') {
@@ -1211,24 +1219,37 @@ export function apply(ctx = {}) {
     }, delay)
   }
 
-  // ---- 启动 ----
-  loadAssets()
-  refresh()
-  pollTimer = setInterval(refresh, cfg.pollMs)
-  const animTimer = setInterval(tick, TICK_MS)
-  scheduleWander()
-  armWorking()
-
-  // ---- SSE 即时事件（v9）：Node half 事件发生时推送，收到立即 refresh() ——
-  // 回合完成庆祝/欢迎/思考陪伴不再等 pollMs 轮询（默认 3s → 单次 /state 往返）。
-  // EventSource 断线自动重连（内建，retry 3s）；轮询保留兜底（SSE 不可用时照常跑）。
-  try {
-    const sse = new EventSource(EVENTS_PATH)
-    sse.onmessage = () => refresh()
-    // onerror 不处理：EventSource 内建自动重连；重连期间轮询兜底，宠物照常。
-  } catch {
-    // EventSource 不可用（罕见）：轮询兜底，宠物照常跑
+  // ---- 启动（enabled 门控）：先取配置判定网页端渲染开关，禁用时不启动任何计时器并卸载 ----
+  // 双宠物场景：桌面伴侣（外部 HTTP 消费者）并存时用户可在设置关掉网页端宠物；
+  // 引导期 host 已隐藏（不闪一下再消失）；运行中热切换由 applyClientConfig 处理。
+  let animTimer = null
+  let sse = null
+  const boot = async () => {
+    const config = await fetchConfig()
+    if (config !== null && config.enabled === false) {
+      dispose()
+      return
+    }
+    if (config !== null) applyClientConfig(config)
+    host.style.display = ''
+    loadAssets()
+    refresh()
+    pollTimer = setInterval(refresh, cfg.pollMs)
+    animTimer = setInterval(tick, TICK_MS)
+    scheduleWander()
+    armWorking()
+    // ---- SSE 即时事件（v9）：Node half 事件发生时推送，收到立即 refresh() ——
+    // 回合完成庆祝/欢迎/思考陪伴不再等 pollMs 轮询（默认 3s → 单次 /state 往返）。
+    // EventSource 断线自动重连（内建，retry 3s）；轮询保留兜底（SSE 不可用时照常跑）。
+    try {
+      sse = new EventSource(EVENTS_PATH)
+      sse.onmessage = () => refresh()
+      // onerror 不处理：EventSource 内建自动重连；重连期间轮询兜底，宠物照常。
+    } catch {
+      // EventSource 不可用（罕见）：轮询兜底，宠物照常跑
+    }
   }
+  boot()
 
   // ---- 会话感知（v8：Node half 聚合，退役本地 sessions 订阅）----
   // 自渲染 client 无 ctx.sessions（官方注入面只给 __DSH_BOOT__），会话状态（think/wait/
@@ -1288,9 +1309,11 @@ export function apply(ctx = {}) {
   dialogObserver.observe(document.body, { childList: true, subtree: true })
   syncInert()
 
-  return () => {
+  // 卸载（enabled=false 与 loader 卸载共用；幂等——计时器/监听器/节点均可重复清理）。
+  const dispose = () => {
     clearInterval(pollTimer)
-    clearInterval(animTimer)
+    if (animTimer !== null) clearInterval(animTimer)
+    if (sse !== null) sse.close()
     clearTimeout(wanderTimer)
     if (workingTimer !== null) clearTimeout(workingTimer)
     if (walkRaf !== null) cancelAnimationFrame(walkRaf)
@@ -1310,6 +1333,7 @@ export function apply(ctx = {}) {
     host.remove()
     style.remove()
   }
+  return dispose
 }
 
 // 标准 bundle client 形态（0811）：exports {name, apply} 经 __ModuleLoader__.load

--- a/.dsh-plugin/client/logic.mjs
+++ b/.dsh-plugin/client/logic.mjs
@@ -20,7 +20,7 @@ export const TRANSIENT_MS = 1500
 export const WAKE_MS = 3000
 export const JOY_MS = 1600
 // 回合完成庆祝窗口（client 本地）：session running→completed 翻转后播 celebrate 的时长。
-export const ROUND_CELEBRATE_MS = 4000
+export { TURN_COMPLETED_MS as ROUND_CELEBRATE_MS } from '../src/snapshot.mjs'
 
 // 状态名权威集合（15 状态，全角色必填素材——缺 sheet 不再 emoji 降级）。
 // 来源：docs/sprites-spec.md 状态总表；verify-spec-states 门禁校验三者一致：

--- a/.dsh-plugin/index.mjs
+++ b/.dsh-plugin/index.mjs
@@ -20,6 +20,7 @@ import { parseTurnEvent } from './src/session-events.mjs'
 import { normalizeState, serializeState } from './src/persistence.mjs'
 import { createSignals } from './src/signals.mjs'
 import { NAMESPACE, DEFAULTS, buildSchema, validateConfig } from './src/config.mjs'
+import { SNAPSHOT_API_VERSION, TURN_COMPLETED_MS, turnCompletionSnapshot } from './src/snapshot.mjs'
 
 export const name = 'whale-girl'
 export const inject = ['jobs', 'agents', 'sessions', 'settings', 'webServer']
@@ -150,11 +151,11 @@ export function apply(ctx) {
   // 轮询下发。信号源：
   // - 思考中（sessionThink）：任一会话处于 turn 之间（有 turn/start 未 turn/end）或已开始未结束
   // - 等待批准（sessionWait）：turn/end 的 reason.kind === 'blocked'（等待用户批准/权限）
-  // - 回合完成（turnCompleted）：turn/end 边沿（每完成一个 turn 触发一次庆祝）
+  // - 回合完成（turnCompleted）：turn/end 边沿后的共享时间窗（每个消费者均可观察）
   const sessionsSvc = typeof ctx.get === 'function' ? ctx.get('sessions') : undefined
   let sessionThink = false
   let sessionWait = false
-  let turnCompleted = false // 单轮翻转标志：activity() 消费后复位
+  let turnCompletedUntil = 0
   const activeTurns = new Map() // sessionId → turn/start 未 turn/end 计数
   const sessionUpdate = () => {
     // 从当前会话列表与 turn 边沿聚合（sessions 服务缺席时保持上次值——宠物照常跑）。
@@ -222,10 +223,14 @@ export function apply(ctx) {
       name = 'welcome'
       until = welcomeUntil
     }
-    // 会话状态随 /state 下发（client 从轮询读，不再直接订阅 sessions）；turnCompleted 单轮消费。
-    const tc = turnCompleted
-    turnCompleted = false
-    return { name, until, sessionThink, sessionWait, turnCompleted: tc }
+    // 绝对截止时间使 /state 成为非消费式快照：Web 与外部伴侣可同时观察同一回合完成。
+    return {
+      name,
+      until,
+      sessionThink,
+      sessionWait,
+      ...turnCompletionSnapshot(turnCompletedUntil, now),
+    }
   }
 
   // webServer 可选（headless 无 web 服务器）：有则注册 state/interact/config/assets/events
@@ -289,7 +294,7 @@ export function apply(ctx) {
         broadcastEvent() // 会话启动/续接 → welcome 或账本更新即刻下发
       }),
       // 会话事件（v8 会话感知）：跟踪 turn/start · turn/end 边沿驱动 think 陪伴与回合完成庆祝。
-      // 无条件注册（不随 sessionsSvc 缺席而丢）：turnCompleted/celebrate 只依赖事件本身；
+      // 无条件注册（不随 sessionsSvc 缺席而丢）：回合完成窗口只依赖事件本身；
       // sessionThink 聚合（sessionUpdate）在 sessions 服务缺席时降级保持上次值（宠物照常跑）。
       ctx.on('session/event', (session, event) => {
         const id = typeof session?.id === 'string' ? session.id : null
@@ -304,7 +309,7 @@ export function apply(ctx) {
           const n = (activeTurns.get(id) ?? 0) - 1
           if (n <= 0) activeTurns.delete(id)
           else activeTurns.set(id, n)
-          turnCompleted = true // 每完成一个 turn 触发一次庆祝（activity() 消费）
+          turnCompletedUntil = Math.max(turnCompletedUntil, Date.now() + TURN_COMPLETED_MS)
           sessionWait = parsed.blocked // turn/end 的 reason 属等待用户（approval 等）
           sessionUpdate()
         }
@@ -327,7 +332,12 @@ export function apply(ctx) {
             // 轮询端点：禁缓存，防止启发式缓存读到冻结状态。
             // 先跑 activity()（有记账副作用），再读 state——响应里的 pet 才是记账后的值。
             const act = activity()
-            json(res, 200, { pet: state, activity: act, configRevision }, { 'cache-control': 'no-store' })
+            json(res, 200, {
+              apiVersion: SNAPSHOT_API_VERSION,
+              pet: state,
+              activity: act,
+              configRevision,
+            }, { 'cache-control': 'no-store' })
           } catch (error) {
             json(res, 500, { error: error instanceof Error ? error.message : String(error) })
           }

--- a/.dsh-plugin/index.mjs
+++ b/.dsh-plugin/index.mjs
@@ -21,12 +21,13 @@ import { normalizeState, serializeState } from './src/persistence.mjs'
 import { createSignals } from './src/signals.mjs'
 import { NAMESPACE, DEFAULTS, buildSchema, validateConfig } from './src/config.mjs'
 import { SNAPSHOT_API_VERSION, TURN_COMPLETED_MS, turnCompletionSnapshot } from './src/snapshot.mjs'
+import { PRESENCE_TTL_MS, pokePresence, companionOnline } from './src/presence.mjs'
 
 export const name = 'whale-girl'
 export const inject = ['jobs', 'agents', 'sessions', 'settings', 'webServer']
 // 路由端点 re-export（来源 src/routes.mjs；保持既有导出面）。
-import { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH } from './src/routes.mjs'
-export { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH }
+import { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH, PRESENCE_PATH } from './src/routes.mjs'
+export { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH, PRESENCE_PATH }
 /** /interact 请求体大小上限（动作只需几字节）。 */
 export const BODY_LIMIT = 1024
 
@@ -144,6 +145,8 @@ export function apply(ctx) {
   let disappointedUntil = 0
   let welcomeUntil = 0
   let celebrateUntil = 0
+  // 桌面伴侣在场窗口（心跳写面，见 src/presence.mjs）：在场时网页端宠物隐藏。
+  let companionUntil = 0
 
   // ---- 会话状态聚合（v8：官方自渲染 client 无 ctx.sessions——Node half 聚合进 /state）----
   // client 自执行脚本 `apply({})` 拿不到宿主 sessions 服务（官方注入面只给 __DSH_BOOT__），
@@ -337,6 +340,7 @@ export function apply(ctx) {
               pet: state,
               activity: act,
               configRevision,
+              companionOnline: companionOnline(companionUntil, Date.now()),
             }, { 'cache-control': 'no-store' })
           } catch (error) {
             json(res, 500, { error: error instanceof Error ? error.message : String(error) })
@@ -392,6 +396,47 @@ export function apply(ctx) {
             }
             const result = applyAction(state, body.action, configRef.replies)
             json(res, result.status, result.body, { 'cache-control': 'no-store' })
+          } catch (error) {
+            json(res, 500, { error: error instanceof Error ? error.message : String(error) })
+          }
+        },
+      }),
+      // ---- 桌面伴侣在场心跳（显示层写面）：桌面端周期性续命，退出/崩溃后 TTL 过期 ----
+      // 在场期间网页端宠物隐藏（/state 的 companionOnline），避免双宠物；无账本语义，
+      // 与 /interact 同级安全面（跨源校验 + body 上限）。见 src/presence.mjs 契约。
+      webServer.register({
+        kind: 'exact',
+        path: PRESENCE_PATH,
+        handler: async (req, res) => {
+          try {
+            if (req.method !== 'POST') {
+              json(res, 405, { error: 'method not allowed; use POST' }, { allow: 'POST' })
+              return
+            }
+            if (isCrossOrigin(req.headers, req.headers.host)) {
+              json(res, 403, { error: 'cross-origin request rejected' })
+              return
+            }
+            const raw = await readBody(req)
+            if (raw === null) {
+              json(res, 413, { error: 'request body too large' })
+              return
+            }
+            let body
+            try {
+              body = JSON.parse(raw || '{}')
+            } catch {
+              json(res, 400, { error: 'invalid JSON body' })
+              return
+            }
+            if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+              json(res, 400, { error: 'body must be a JSON object' })
+              return
+            }
+            // online 缺省视为上线（裸 {} 即可续命）；false 显式下线（桌面端退出时即时恢复网页端）。
+            const online = body.online !== false
+            companionUntil = pokePresence(companionUntil, Date.now(), online)
+            json(res, 200, { online: companionOnline(companionUntil, Date.now()) }, { 'cache-control': 'no-store' })
           } catch (error) {
             json(res, 500, { error: error instanceof Error ? error.message : String(error) })
           }

--- a/.dsh-plugin/src/config.mjs
+++ b/.dsh-plugin/src/config.mjs
@@ -16,6 +16,7 @@ export const NAMESPACE = 'whale-girl'
 
 /** 体验层默认值（消费端唯一权威）。数值已 clamp 到安全域。 */
 export const DEFAULTS = Object.freeze({
+  enabled: true,          // 网页端渲染开关（桌面伴侣并存时设 false 关闭网页端宠物，避免双宠物）
   size: 110,              // 宠物尺寸 px（stage 盒 + sprite 上限）
   opacity: 1,             // 常态透明度 0.2–1（inert 0.25 是交互态，不在此配）
   walk: {
@@ -42,6 +43,7 @@ export const DEFAULTS = Object.freeze({
 /** schemastery schema（settings.register 用；默认值= DEFAULTS，防双源漂移）。 */
 export function buildSchema() {
   return z.object({
+    enabled: z.boolean().default(DEFAULTS.enabled),
     size: z.number().min(64).max(160).default(DEFAULTS.size),
       opacity: z.number().min(0.2).max(1).default(DEFAULTS.opacity),
       walk: z.object({

--- a/.dsh-plugin/src/presence.mjs
+++ b/.dsh-plugin/src/presence.mjs
@@ -1,0 +1,15 @@
+// 桌面伴侣在场信号（显示层）：心跳写面 + 过期语义。
+// 契约：桌面端（外部 HTTP 消费者）周期性 POST /whale-girl/presence { online: true }
+// 续命，退出/崩溃后心跳过期 → 网页端宠物自动恢复（崩溃安全，无需手动开关）。
+// 零宿主依赖、可单测。
+export const PRESENCE_TTL_MS = 45000 // 心跳有效窗口（桌面端每 15s 续命一次）
+
+/** 心跳续命/下线：返回新的在场截止时刻（online=false 立即下线）。 */
+export function pokePresence(companionUntil, nowMs, online = true) {
+  return online ? nowMs + PRESENCE_TTL_MS : 0
+}
+
+/** 当前是否处于桌面伴侣在场窗口内（companionUntil 为截止时刻）。 */
+export function companionOnline(companionUntil, nowMs) {
+  return companionUntil > nowMs
+}

--- a/.dsh-plugin/src/routes.mjs
+++ b/.dsh-plugin/src/routes.mjs
@@ -9,3 +9,4 @@ export const INTERACT_PATH = `${ROUTE_PREFIX}/interact`
 export const CONFIG_PATH = `${ROUTE_PREFIX}/config`
 export const ASSETS_PATH = `${ROUTE_PREFIX}/assets`
 export const EVENTS_PATH = `${ROUTE_PREFIX}/events`
+export const PRESENCE_PATH = `${ROUTE_PREFIX}/presence`

--- a/.dsh-plugin/src/snapshot.mjs
+++ b/.dsh-plugin/src/snapshot.mjs
@@ -1,0 +1,9 @@
+// Read-only snapshot wire contract shared by the Node half and all clients.
+export const SNAPSHOT_API_VERSION = 1
+export const TURN_COMPLETED_MS = 4000
+
+/** A completion window is observable by every reader until its absolute deadline. */
+export function turnCompletionSnapshot(until, nowMs) {
+  const safeUntil = Number.isFinite(until) && until > 0 ? until : 0
+  return { turnCompleted: safeUntil > nowMs, turnCompletedUntil: safeUntil }
+}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ dsh plugin --profile web add "github:vlln/whale-girl#main"   # 推荐：git 源�
 
 ```yaml
 whale-girl:
+  enabled: true      # 网页端渲染开关（与桌面伴侣并存时设 false 关闭网页端宠物，避免双宠物）
   size: 110          # 宠物尺寸 px（64–160）
   opacity: 1         # 常态透明度（0.2–1）
   walk:

--- a/decisions/implemented/architecture/2026-08-08-in-gui-pet-architecture.md
+++ b/decisions/implemented/architecture/2026-08-08-in-gui-pet-architecture.md
@@ -2,6 +2,8 @@
 
 Status: implemented
 
+部分消费边界已由 [外部只读快照契约](2026-08-14-external-snapshot-contract.md) 取代：GUI 仍是本仓库唯一分发的界面，但本地外部伴侣可以非消费式读取状态。
+
 ## Problem
 
 目标是一个"类似 QQ 宠物"的插件。QQ 宠物的原型是挂载在 OS 桌面上的原生悬浮窗。plugin-registry 插件的 client half 只能跑在 DSH Web GUI 的浏览器页面里，无法脱离浏览器挂到原生桌面；需要决定宠物以什么形态落地。

--- a/decisions/implemented/architecture/2026-08-14-external-snapshot-contract.md
+++ b/decisions/implemented/architecture/2026-08-14-external-snapshot-contract.md
@@ -1,0 +1,28 @@
+# Decision: 外部只读快照契约
+
+Status: implemented
+
+## Problem
+
+`/whale-girl/state` 原为单个 Web client 的轮询面；读取会消费 `turnCompleted` 翻转标志。Web client 与桌面伴侣并存时，先读取者会令另一消费者丢失回合完成反馈，现有响应也没有可判定兼容性的版本。
+
+## Decision
+
+`GET /whale-girl/state` 是本地外部消费者可依赖的只读快照契约，响应带 `apiVersion: 1`。回合完成状态由绝对截止时间 `turnCompletedUntil` 表达，并保留派生 boolean `turnCompleted`；读取不修改截止时间，因此任意数量消费者可观察同一窗口。SSE `/whale-girl/events` 只提示消费者刷新快照，不承载唯一事件数据。
+
+本决策部分取代 [GUI 内桌面宠物架构](../architecture/2026-08-08-in-gui-pet-architecture.md) 中「只有一个 GUI client 消费状态」的边界，但不改变宠物仍以 GUI 内形态分发的决定；外部桌面程序不进入本仓库。
+
+## Alternatives considered
+
+**新增仅供桌面端使用的 endpoint。** 会产生两个快照协议与漂移风险；现有 `/state` 已包含所需事实，修正其多消费者语义更小。
+
+**把完整事件载荷放进 SSE。** 需要事件序列、重放与断线语义，远超本次只读查询需求；SSE 保持无状态刷新通知，完整事实仍由快照提供。
+
+**继续消费式 boolean。** 多消费者存在确定性竞态，无法作为外部契约。
+
+## Consequences
+
+- 重复或并发读取 `/state` 不再吞掉回合完成反馈。
+- client 使用服务端绝对截止时间，不因轮询重复延长庆祝动画。
+- `apiVersion` 只标识 wire 破坏性变化；同版本允许增加未知字段，消费者必须忽略。
+- 外部消费者仍依赖运行中的 DSH Web profile，并负责断线重连与轮询兜底。

--- a/decisions/implemented/feature/2026-08-14-web-pet-disable-switch.md
+++ b/decisions/implemented/feature/2026-08-14-web-pet-disable-switch.md
@@ -1,0 +1,27 @@
+# Decision: 网页端宠物渲染开关
+
+Status: implemented
+
+## Problem
+
+桌面伴侣（dsh-desktop-pet，外部 HTTP 消费者）与网页端宠物并存时出现「两条大肥鱼」：同一 DSH profile 上同时渲染两个宠物。外部消费者无法卸载网页端宠物，用户也没有关闭入口。
+
+## Decision
+
+体验层配置项 `enabled`（默认 `true`，settings 可配，热生效）控制网页端 client 是否渲染宠物：
+
+- client `apply()` 挂载后先取配置判定：`enabled: false` 时不启动任何计时器/轮询/SSE 并立即卸载；挂载期 host 隐藏，禁用时不闪一下再消失。
+- 运行中热切换为 `false`（configRevision 变化 → `applyClientConfig`）立即卸载；重新启用需刷新页面（client 自渲染无重建路径）。配置缺失（旧 Node half）视为启用，向后兼容。
+- Node half 端点（`/state` `/events` `/interact` `/config` `/assets`）不受影响——桌面伴侣等外部消费者照常读取账本与信号。
+
+## Alternatives considered
+
+**桌面伴侣启动时调用隐藏端点（如 `POST /visibility`）。** 有状态且崩溃恢复差：桌面进程被 kill 后网页端宠物永久隐藏直到再次显式恢复；多消费者并发语义复杂。配置开关无状态、持久化、崩溃安全。
+
+**仅在桌面伴侣侧隐藏（不动 whale-girl）。** 网页端宠物对普通浏览器用户仍渲染，问题未根治；关闭入口属于 whale-girl 的能力面。
+
+## Consequences
+
+- 双宠物场景由用户显式关闭网页端宠物消除，设置持久化（settings 服务落盘）。
+- `enabled` 是客户端渲染开关，不影响账本、信号与外部消费契约（`docs/external-consumers.md` 不变）。
+- 重新启用需刷新页面——已知边界，记录于 config 注释与本文。

--- a/decisions/implemented/feature/2026-08-14-web-pet-disable-switch.md
+++ b/decisions/implemented/feature/2026-08-14-web-pet-disable-switch.md
@@ -8,20 +8,22 @@ Status: implemented
 
 ## Decision
 
-体验层配置项 `enabled`（默认 `true`，settings 可配，热生效）控制网页端 client 是否渲染宠物：
+网页端宠物渲染由两个互补机制控制：
 
-- client `apply()` 挂载后先取配置判定：`enabled: false` 时不启动任何计时器/轮询/SSE 并立即卸载；挂载期 host 隐藏，禁用时不闪一下再消失。
-- 运行中热切换为 `false`（configRevision 变化 → `applyClientConfig`）立即卸载；重新启用需刷新页面（client 自渲染无重建路径）。配置缺失（旧 Node half）视为启用，向后兼容。
-- Node half 端点（`/state` `/events` `/interact` `/config` `/assets`）不受影响——桌面伴侣等外部消费者照常读取账本与信号。
+**手动开关（配置）**：体验层配置项 `enabled`（默认 `true`，settings 可配，热生效）。client `apply()` 挂载后先取配置判定：`enabled: false` 时不启动任何计时器/轮询/SSE 并立即卸载；挂载期 host 隐藏，禁用时不闪一下再消失。运行中热切换为 `false`（configRevision 变化 → `applyClientConfig`）立即卸载；重新启用需刷新页面。配置缺失（旧 Node half）视为启用，向后兼容。
+
+**桌面伴侣在场心跳（自动）**：`POST /whale-girl/presence`（显示层写面，跨源校验 + body 上限，与 `/interact` 同级安全面，见 `src/presence.mjs`）。桌面端运行期间每 15s 续命（`{ online: true }`，TTL 45s），干净退出时发 `{ online: false }` 即时下线。`/state` 下发 `companionOnline` 布尔；在场期间网页端 client 隐藏宠物（`syncInert` 的 `companion` 分支），心跳过期后自动恢复显示——桌面端被杀/崩溃也不会让网页端永久隐藏。
+
+Node half 端点（`/state` `/events` `/interact` `/config` `/assets`）不受影响——桌面伴侣等外部消费者照常读取账本与信号。
 
 ## Alternatives considered
 
-**桌面伴侣启动时调用隐藏端点（如 `POST /visibility`）。** 有状态且崩溃恢复差：桌面进程被 kill 后网页端宠物永久隐藏直到再次显式恢复；多消费者并发语义复杂。配置开关无状态、持久化、崩溃安全。
+**桌面伴侣启动时调用无状态隐藏端点（如 `POST /visibility { visible: false }` 直到显式恢复）。** 崩溃恢复差：桌面进程被 kill 后网页端宠物永久隐藏直到再次显式恢复；多消费者并发语义复杂。心跳 + TTL 变体解决该缺陷（本决策采用），无状态版本弃。
 
 **仅在桌面伴侣侧隐藏（不动 whale-girl）。** 网页端宠物对普通浏览器用户仍渲染，问题未根治；关闭入口属于 whale-girl 的能力面。
 
 ## Consequences
 
-- 双宠物场景由用户显式关闭网页端宠物消除，设置持久化（settings 服务落盘）。
-- `enabled` 是客户端渲染开关，不影响账本、信号与外部消费契约（`docs/external-consumers.md` 不变）。
-- 重新启用需刷新页面——已知边界，记录于 config 注释与本文。
+- 双宠物场景默认自动消除：桌面端在线即隐藏网页端宠物，退出/崩溃后 ≤45s 自动恢复；手动 `enabled` 开关仍可用作兜底。
+- `enabled` 与 presence 都是显示层控制，不影响账本、信号与外部消费契约（`docs/external-consumers.md` 已更新 presence 契约）。
+- 重新启用 `enabled` 需刷新页面——已知边界，记录于 config 注释与本文。

--- a/docs/external-consumers.md
+++ b/docs/external-consumers.md
@@ -8,6 +8,7 @@ Local companion applications may read whale-girl state from a running DSH Web pr
 - `GET /whale-girl/events` is an SSE refresh signal. Fetch `/state` after each message and retain polling as a reconnect fallback.
 - `GET /whale-girl/config` returns the current presentation configuration.
 - `GET /whale-girl/assets/*` serves the character manifest and sprite sheets.
+- `POST /whale-girl/presence` is the desktop-companion heartbeat (display-layer write, cross-origin guarded). A companion application that replaces the in-page pet posts `{ "online": true }` every 15s while running, and `{ "online": false }` on clean exit. While the presence window (45s TTL) is active, `/state` reports `companionOnline: true` and the in-page pet hides itself; if the companion dies without a farewell, the window expires and the in-page pet returns automatically.
 
 The snapshot response is:
 
@@ -23,7 +24,8 @@ The snapshot response is:
     "turnCompleted": false,
     "turnCompletedUntil": 0
   },
-  "configRevision": 1
+  "configRevision": 1,
+  "companionOnline": false
 }
 ```
 

--- a/docs/external-consumers.md
+++ b/docs/external-consumers.md
@@ -1,0 +1,44 @@
+# External consumers
+
+Local companion applications may read whale-girl state from a running DSH Web profile. The snapshot is read-only and non-consuming: multiple clients can observe the same activity windows without stealing events from one another.
+
+## Endpoints
+
+- `GET /whale-girl/state` returns the current snapshot with `cache-control: no-store`.
+- `GET /whale-girl/events` is an SSE refresh signal. Fetch `/state` after each message and retain polling as a reconnect fallback.
+- `GET /whale-girl/config` returns the current presentation configuration.
+- `GET /whale-girl/assets/*` serves the character manifest and sprite sheets.
+
+The snapshot response is:
+
+```json
+{
+  "apiVersion": 1,
+  "pet": {},
+  "activity": {
+    "name": "idle",
+    "until": 0,
+    "sessionThink": false,
+    "sessionWait": false,
+    "turnCompleted": false,
+    "turnCompletedUntil": 0
+  },
+  "configRevision": 1
+}
+```
+
+`turnCompletedUntil` is an absolute Unix timestamp in milliseconds. Consumers should use it as the animation deadline; `turnCompleted` is the corresponding convenience boolean. Unknown fields may be added compatibly within an API version.
+
+```js
+const base = 'http://127.0.0.1:3080'
+const readState = async () => {
+  const response = await fetch(`${base}/whale-girl/state`)
+  if (!response.ok) throw new Error(`whale-girl state: HTTP ${response.status}`)
+  return response.json()
+}
+
+const events = new EventSource(`${base}/whale-girl/events`)
+events.onmessage = async () => render(await readState())
+```
+
+Keep DSH bound to loopback when its local state should not be visible to other machines. Consumers must tolerate the server being unavailable during DSH startup, shutdown, and profile restarts.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -96,6 +96,6 @@
 | `tasks.onTaskDone` | 记账 + celebrate/failure 窗口 | `activity` |
 | `agent/session-start` | 会话 XP + welcome 窗口 | `activity` |
 | `agent/request-error` | error/disappointed 窗口 | `activity` |
-| sessions.list 快照 | — | `sessionThink` / `sessionWait` / 回合完成翻转→`celebrateUntil` |
+| sessions.list 快照 | — | `sessionThink` / `sessionWait` / 非消费式回合完成截止时间→`celebrateUntil` |
 | 节奏器（client 本地） | — | `workingActive`（随机插曲）/ `celebrateUntil`（回合完成窗口） |
 | 用户 pointer/点击 | — | `dragging` / `transient` / `joyUntil` / `wakeFromInteraction`（交互醒觉：拖拽/喂食/玩耍/开菜单重置空闲 + 睡着则 wake） |

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -9,6 +9,7 @@ test('NAMESPACE 与 DEFAULTS 完整性', () => {
   assert.equal(NAMESPACE, 'whale-girl')
   assert.equal(typeof DEFAULTS.size, 'number')
   assert.equal(DEFAULTS.size, 110)
+  assert.equal(DEFAULTS.enabled, true)
   assert.equal(DEFAULTS.walk.enabled, true)
   assert.equal(DEFAULTS.walk.maxWaitMs, 40000)
 })

--- a/tests/presence.test.mjs
+++ b/tests/presence.test.mjs
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PRESENCE_TTL_MS, pokePresence, companionOnline } from '../.dsh-plugin/src/presence.mjs'
+
+test('presence TTL is a positive finite window', () => {
+  assert.ok(Number.isFinite(PRESENCE_TTL_MS) && PRESENCE_TTL_MS > 0)
+})
+
+test('online poke extends the presence window from now', () => {
+  const until = pokePresence(0, 1000, true)
+  assert.equal(until, 1000 + PRESENCE_TTL_MS)
+  // 连续续命窗口顺延（不叠加，只取最新）
+  const next = pokePresence(until, 1000 + 10000, true)
+  assert.equal(next, 1000 + 10000 + PRESENCE_TTL_MS)
+})
+
+test('offline poke ends the window immediately', () => {
+  assert.equal(pokePresence(99999, 1000, false), 0)
+  assert.equal(companionOnline(0, 1000), false)
+})
+
+test('companionOnline flips at the absolute deadline', () => {
+  const until = 1000 + PRESENCE_TTL_MS
+  assert.equal(companionOnline(until, 1000), true)
+  assert.equal(companionOnline(until, until - 1), true)
+  assert.equal(companionOnline(until, until), false)
+})

--- a/tests/snapshot.test.mjs
+++ b/tests/snapshot.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  SNAPSHOT_API_VERSION,
+  TURN_COMPLETED_MS,
+  turnCompletionSnapshot,
+} from '../.dsh-plugin/src/snapshot.mjs'
+
+test('snapshot contract has an explicit initial version', () => {
+  assert.equal(SNAPSHOT_API_VERSION, 1)
+})
+
+test('turn completion is non-consuming for multiple readers', () => {
+  const until = 1000 + TURN_COMPLETED_MS
+  const first = turnCompletionSnapshot(until, 1000)
+  const second = turnCompletionSnapshot(until, 1000)
+  assert.deepEqual(first, second)
+  assert.deepEqual(first, { turnCompleted: true, turnCompletedUntil: until })
+})
+
+test('turn completion expires at its absolute deadline', () => {
+  const until = 5000
+  assert.equal(turnCompletionSnapshot(until, 4999).turnCompleted, true)
+  assert.deepEqual(
+    turnCompletionSnapshot(until, 5000),
+    { turnCompleted: false, turnCompletedUntil: until },
+  )
+})
+
+test('invalid completion deadlines degrade to an inactive window', () => {
+  assert.deepEqual(
+    turnCompletionSnapshot(Number.NaN, 1000),
+    { turnCompleted: false, turnCompletedUntil: 0 },
+  )
+})


### PR DESCRIPTION
支持桌宠客户端

## 背景

- `/whale-girl/state` 原本按单个客户端设计：读取时消费 `turnCompleted` 标记，多客户端并发会互相抢占状态。
- 桌面伴侣运行时与网页端宠物同时渲染，需要一个关闭网页端宠物的入口。

## 改动

**1. 非消费式多客户端快照**

- `/state` 增加 `apiVersion: 1`
- `turnCompleted` 改为基于绝对截止时间（`turnCompletedUntil`），任意数量消费者共享同一完成窗口，读取不再互相抢占
- Web 客户端改用服务端截止时间，不因重复轮询延长庆祝动画
- 补充 `docs/external-consumers.md` 与 snapshot 单测

**2. 网页端渲染开关（`enabled`）**

- 配置项 `enabled`（默认 `true`，settings 可配、热生效）控制网页端 client 是否渲染
- 桌面伴侣并存时可在设置里关掉网页端宠物；重新启用需刷新页面

**3. 桌面伴侣在场心跳（presence）**

- `POST /whale-girl/presence`（跨源校验 + body 上限，显示层写面）：桌面端每 15s 续命（TTL 45s），退出时发 `{online:false}`
- `/state` 下发 `companionOnline`；在场期间网页端宠物自动隐藏，心跳过期（≤45s）自动恢复——桌面端崩溃也不会让网页端永久隐藏

## 不变

现有网页端宠物的安装方式与交互不变；外部消费者自行负责断线重连与轮询兜底。
