### PR TITLE
feat: per-session activity endpoint (GET /whale-girl/sessions)

### DIFF
--- a/.dsh-plugin/index.mjs
+++ b/.dsh-plugin/index.mjs
@@ -17,6 +17,7 @@ import { deriveActivity, mergeCelebrate } from './src/activity.mjs'
 import { sanitizeAssetPath, contentTypeFor, ASSETS_PATH } from './src/assets.mjs'
 import { applyAction, isCrossOrigin } from './src/interact.mjs'
 import { parseTurnEvent } from './src/session-events.mjs'
+import { createSessionView, applySessionView, titleFromLog } from './src/sessions.mjs'
 import { normalizeState, serializeState } from './src/persistence.mjs'
 import { createSignals } from './src/signals.mjs'
 import { NAMESPACE, DEFAULTS, buildSchema, validateConfig } from './src/config.mjs'
@@ -24,8 +25,8 @@ import { NAMESPACE, DEFAULTS, buildSchema, validateConfig } from './src/config.m
 export const name = 'whale-girl'
 export const inject = ['jobs', 'agents', 'sessions', 'settings', 'webServer']
 // 路由端点 re-export（来源 src/routes.mjs；保持既有导出面）。
-import { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH } from './src/routes.mjs'
-export { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH }
+import { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH, SESSIONS_PATH } from './src/routes.mjs'
+export { STATE_PATH, INTERACT_PATH, CONFIG_PATH, ROUTE_PREFIX, EVENTS_PATH, SESSIONS_PATH }
 /** /interact 请求体大小上限（动作只需几字节）。 */
 export const BODY_LIMIT = 1024
 
@@ -152,10 +153,27 @@ export function apply(ctx) {
   // - 等待批准（sessionWait）：turn/end 的 reason.kind === 'blocked'（等待用户批准/权限）
   // - 回合完成（turnCompleted）：turn/end 边沿（每完成一个 turn 触发一次庆祝）
   const sessionsSvc = typeof ctx.get === 'function' ? ctx.get('sessions') : undefined
+  // 会话标题权威源（dsh-session-title）：重启后历史 session/title 事件不可见，
+  // 靠该服务补全（get(session)?.title）。缺席时退回事件日志标题。
+  const sessionTitleSvc = typeof ctx.get === 'function' ? ctx.get('sessionTitle') : undefined
   let sessionThink = false
   let sessionWait = false
   let turnCompleted = false // 单轮翻转标志：activity() 消费后复位
   const activeTurns = new Map() // sessionId → turn/start 未 turn/end 计数
+  // 每会话活动账本（/sessions 端点）：sessionId → { id, title, activity, since }。
+  // 事件驱动更新（session/event 回调）；sessions 服务缺席时降级为仅事件视图。
+  const sessionViews = new Map()
+  // 标题解析：事件日志（titleFromLog）优先，sessionTitle 服务兜底（重启后补历史标题）。
+  const resolveSessionTitle = (s) => {
+    const fromLog = titleFromLog(Array.isArray(s?.events) ? s.events : [])
+    if (fromLog !== null) return fromLog
+    try {
+      const snapshot = sessionTitleSvc?.get?.(s)
+      return typeof snapshot?.title === 'string' && snapshot.title !== '' ? snapshot.title : null
+    } catch {
+      return null
+    }
+  }
   const sessionUpdate = () => {
     // 从当前会话列表与 turn 边沿聚合（sessions 服务缺席时保持上次值——宠物照常跑）。
     if (sessionsSvc === undefined || typeof sessionsSvc.list !== 'function') return
@@ -171,6 +189,38 @@ export function apply(ctx) {
     } catch {
       // 列表异常：保留上次值
     }
+  }
+  // 每会话活动快照（/sessions 端点）：事件视图为主，sessions 列表兜底——
+  // 未在事件流出现的会话（如插件加载前已存在）用列表事件日志补标题、
+  // header.createdAt 补 since；列表缺席时只返回事件视图（宠物照常跑）。
+  // 列表可用时清理由已结束会话（不再出现在列表）的视图——"会话结束后框消失"。
+  const sessionsSnapshot = () => {
+    if (sessionsSvc !== undefined && typeof sessionsSvc.list === 'function') {
+      try {
+        const live = new Set()
+        for (const s of sessionsSvc.list()) {
+          if (s === null || typeof s !== 'object') continue
+          const id = typeof s.id === 'string' ? s.id : null
+          if (id === null) continue
+          live.add(id)
+          const since = typeof s.header?.createdAt === 'number' ? s.header.createdAt : Date.now()
+          const title = resolveSessionTitle(s)
+          const known = sessionViews.get(id)
+          if (known === undefined) {
+            sessionViews.set(id, { id, title, activity: 'done', since })
+          } else if (known.title === null && title !== null) {
+            // 已知会话也补标题（重启后标题服务能拿到、事件流看不到的场景）。
+            sessionViews.set(id, { ...known, title })
+          }
+        }
+        for (const id of sessionViews.keys()) {
+          if (!live.has(id)) sessionViews.delete(id)
+        }
+      } catch {
+        // 列表异常：保持事件视图
+      }
+    }
+    return [...sessionViews.values()]
   }
 
   // ---- pet 服务信号（开放性窄缝，供其他插件 ctx.pet.onSignal 订阅）----
@@ -294,6 +344,15 @@ export function apply(ctx) {
       ctx.on('session/event', (session, event) => {
         const id = typeof session?.id === 'string' ? session.id : null
         if (id === null) return
+        // 每会话活动账本（/sessions 端点数据源）：turn/start → thinking、
+        // tool/call → tool:<name>、turn/end（blocked → waiting / 其余 → done）、
+        // session/title → 标题。会话未出现在事件流时在 /sessions 兜底
+        // （titleFromLog 从列表 meta/事件日志取标题，since 取 header.createdAt）。
+        const known = sessionViews.get(id)
+        const since = known?.since ?? (typeof session?.header?.createdAt === 'number' ? session.header.createdAt : Date.now())
+        const base = known ?? { ...createSessionView(id, since), title: resolveSessionTitle(session) }
+        const view = applySessionView(base, event)
+        if (known === undefined || view !== known) sessionViews.set(id, view)
         const parsed = parseTurnEvent(event)
         if (parsed === null) return
         if (parsed.kind === 'start') {
@@ -382,6 +441,25 @@ export function apply(ctx) {
             }
             const result = applyAction(state, body.action, configRef.replies)
             json(res, result.status, result.body, { 'cache-control': 'no-store' })
+          } catch (error) {
+            json(res, 500, { error: error instanceof Error ? error.message : String(error) })
+          }
+        },
+      }),
+      // ---- 每会话活动（/sessions 端点）----
+      // 外部消费者（桌面伴侣的消息框）按会话读取活动：thinking / tool:<name> /
+      // waiting / done。数据源是 session/event 事件流（sessionViews 账本），
+      // sessions 列表兜底补标题与开始时间；禁缓存（活动随事件实时变化）。
+      webServer.register({
+        kind: 'exact',
+        path: SESSIONS_PATH,
+        handler: async (req, res) => {
+          try {
+            if (req.method !== 'GET') {
+              json(res, 405, { error: 'method not allowed; use GET' }, { allow: 'GET' })
+              return
+            }
+            json(res, 200, sessionsSnapshot(), { 'cache-control': 'no-store' })
           } catch (error) {
             json(res, 500, { error: error instanceof Error ? error.message : String(error) })
           }

--- a/.dsh-plugin/src/routes.mjs
+++ b/.dsh-plugin/src/routes.mjs
@@ -9,3 +9,4 @@ export const INTERACT_PATH = `${ROUTE_PREFIX}/interact`
 export const CONFIG_PATH = `${ROUTE_PREFIX}/config`
 export const ASSETS_PATH = `${ROUTE_PREFIX}/assets`
 export const EVENTS_PATH = `${ROUTE_PREFIX}/events`
+export const SESSIONS_PATH = `${ROUTE_PREFIX}/sessions`

--- a/.dsh-plugin/src/sessions.mjs
+++ b/.dsh-plugin/src/sessions.mjs
@@ -1,0 +1,85 @@
+// 每会话活动账本（GET /whale-girl/sessions 数据源）：纯函数，从宿主会话事件
+// 推导每会话活动（零宿主依赖，可单测）。
+// 契约：
+// - 输入是宿主 `session/event` 回调的第二个参数（append 日志条目，结构与官方
+//   `@deepseek-ai/dsh-session` 的 SessionEvent 一致）：{ type, seq, time, data }。
+// - 事件类型字段是 `type`（'turn/start' | 'turn/end' | 'tool/call' |
+//   'session/title' | ...），与 session-events.mjs 同一事实源。
+// - 活动取值（closed set）：'thinking'（深度思考中）/ 'tool:<name>'（执行工具，
+//   桌面端对 bash/pwsh 显示"运行命令行中"）/ 'waiting'（等待批准）/
+//   'done'（回合完成/无事件的新会话默认）。
+// - 返回 null（非活动事件/结构异常）或 { kind: 'activity' | 'title', value }；
+//   turn/start → thinking；tool/call → tool:<name>；turn/end 的
+//   reason.kind === 'blocked' → waiting，其余结束原因 → done；
+//   session/title → 会话标题（仅标题，不改活动）。
+// - applySessionView 是不可变更新：输入视图不被修改，返回新视图或原视图
+//   （无变化时返回原引用，调用方可用 === 判断是否需要落账）。
+
+/**
+ * 从一条会话事件推导活动/标题变化。
+ * @param {unknown} event 宿主 session/event 回调的事件参数
+ * @returns {null | { kind: 'activity', value: string } | { kind: 'title', value: string }}
+ */
+export function parseSessionEvent(event) {
+  if (event === null || typeof event !== 'object') return null
+  const type = typeof event.type === 'string' ? event.type : null
+  const data = typeof event.data === 'object' && event.data !== null ? event.data : null
+  if (type === 'turn/start') return { kind: 'activity', value: 'thinking' }
+  if (type === 'tool/call') {
+    const name = data !== null && typeof data.name === 'string' ? data.name : null
+    if (name === null || name === '') return null
+    return { kind: 'activity', value: `tool:${name}` }
+  }
+  if (type === 'turn/end') {
+    const reason = data !== null ? data.reason : null
+    const blocked = typeof reason === 'object' && reason !== null && reason.kind === 'blocked'
+    return { kind: 'activity', value: blocked ? 'waiting' : 'done' }
+  }
+  if (type === 'session/title') {
+    const title = data !== null && typeof data.title === 'string' ? data.title : null
+    if (title === null || title === '') return null
+    return { kind: 'title', value: title }
+  }
+  return null
+}
+
+/**
+ * 一条会话视图：{ id, title, activity, since }。
+ * @param {string} id 会话 id
+ * @param {number} since 会话开始时间（Unix epoch ms）
+ */
+export function createSessionView(id, since) {
+  return { id, title: null, activity: 'done', since }
+}
+
+/**
+ * 把一条会话事件应用到视图（不可变）。
+ * @param {{ id: string, title: string | null, activity: string, since: number }} view
+ * @param {unknown} event 宿主会话事件
+ * @returns {typeof view} 新视图；事件不改变视图时返回原引用
+ */
+export function applySessionView(view, event) {
+  const parsed = parseSessionEvent(event)
+  if (parsed === null) return view
+  if (parsed.kind === 'title') {
+    if (parsed.value === view.title) return view
+    return { ...view, title: parsed.value }
+  }
+  if (parsed.value === view.activity) return view
+  return { ...view, activity: parsed.value }
+}
+
+/**
+ * 从会话事件日志兜底取标题（最后一个非空 session/title 事件）。
+ * @param {readonly unknown[]} events 会话事件日志
+ * @returns {string | null}
+ */
+export function titleFromLog(events) {
+  if (!Array.isArray(events)) return null
+  let title = null
+  for (const event of events) {
+    const parsed = parseSessionEvent(event)
+    if (parsed !== null && parsed.kind === 'title') title = parsed.value
+  }
+  return title
+}

--- a/decisions/implemented/feature/2026-08-15-sessions-endpoint.md
+++ b/decisions/implemented/feature/2026-08-15-sessions-endpoint.md
@@ -1,0 +1,31 @@
+# Decision: 每会话活动端点 /whale-girl/sessions
+
+Status: implemented
+
+## Problem
+
+桌面伴侣需要"宠物上方 N 个消息框"显示各会话标题与当前动作（深度思考中 / 执行某某工具 / 运行命令行中 / 等待批准）。`/whale-girl/state` 只聚合全局会话感知（sessionThink / sessionWait / turnCompleted），无法区分"哪个会话在做什么"；桌宠消息框必须按会话读取活动。
+
+## Decision
+
+新增 `GET /whale-girl/sessions`，返回 `[{ id, title, activity, since }]` 数组（无 apiVersion——纯列表契约，字段可兼容增补）。`activity` 取值封闭集合：`thinking`（深度思考中）/ `tool:<name>`（执行工具，桌面端对 bash/pwsh 显示"运行命令行中"）/ `waiting`（等待批准）/ `done`（回合完成）。响应 `cache-control: no-store`（活动随事件实时变化）。
+
+数据源是既有 `session/event` 事件流（与 /state 的会话感知同源，不新增宿主依赖）：`turn/start` → thinking、`tool/call`（data.name）→ tool:&lt;name&gt;、`turn/end`（reason.kind === 'blocked' → waiting / 其余 → done）、`session/title`（data.title）→ 标题。纯逻辑在 `.dsh-plugin/src/sessions.mjs`（零宿主依赖，可单测）；Node half 维护 `sessionViews` 账本，事件回调时应用视图更新，`/sessions` 请求时快照。
+
+兜底：未出现在事件流的会话（如插件加载前已存在）用 `sessions.list()` 补录——标题从会话事件日志取最后一个 `session/title`（titleFromLog），`since` 取 `header.createdAt`；列表缺席（headless 无 sessions 服务）时只返回事件视图。列表可用时清理已结束会话的视图（不再出现在列表 → 从响应消失，即"会话结束后框消失"）。
+
+## Alternatives considered
+
+**扩展 /state 加 per-session 数组。** 会改变既有快照契约的消费者语义（apiVersion 1 契约已发布给桌宠），且 /state 高频轮询、/sessions 只在有会话时才有意义，分开端点职责更清晰。
+
+**在 SSE /events 里携带活动载荷。** 需要事件序列、重放与断线语义，超出桌宠轮询 + IPC 下发的需求；SSE 保持刷新信号、/sessions 提供完整事实（与 /state 同一轮询循环，桌宠实现最简）。
+
+**从 tasks/jobs 服务推导活动。** 会话活动（思考/工具/等待）本质是会话事件流的事实，jobs 只是任务的子集；用事件流与 /state 同源，避免两个事实源漂移。
+
+## Consequences
+
+- 桌宠 main 进程与 /state 同循环轮询 /sessions，IPC 下发渲染器，会话结束后消息框消失。
+- 事件流与 /state 共用同一 `session/event` 订阅，无新增宿主导入；sessions 服务缺席时降级为仅事件视图。
+- 未知字段可兼容增补；`activity` 封闭集合外的新取值由消费端兜底显示。
+- 外部消费者仍依赖运行中的 DSH Web profile，并负责断线重连与轮询兜底（与 /state 相同）。
+- 本端点是对 #1 外部只读快照契约（external-consumer contract，作者 xiaoshihou514）的按会话补充：/state 提供聚合情绪，/sessions 提供每会话明细，二者共同支撑桌面伴侣等外部消费者。

--- a/docs/sessions-endpoint.md
+++ b/docs/sessions-endpoint.md
@@ -1,0 +1,37 @@
+# 每会话活动端点
+
+`GET /whale-girl/sessions` 返回每个运行中会话一行——会话标题与其当前活动。它是 `/whale-girl/state` 聚合情绪（sessionThink / sessionWait）的按会话补充：外部消费者（如桌面伴侣的消息气泡）从这里按会话读取明细。
+
+## 响应
+
+```json
+[
+  {
+    "id": "session-<id>",
+    "title": "会话标题或 null",
+    "activity": "thinking",
+    "since": 1786793963547
+  }
+]
+```
+
+- `activity` 是封闭集合：`thinking`（回合进行中，深度思考）、`tool:<name>`（工具调用运行中；`bash`/`pwsh` 表示命令行执行中）、`waiting`（回合被阻塞等待批准）、`done`（回合完成）。
+- `title` 取会话日志中最近的 `session/title`，或 `sessionTitle` 服务值；未知时为 `null`。
+- `since` 为会话开始时间（Unix epoch 毫秒）。
+- 会话离开 `sessions.list()` 后其行被移除——已结束会话的气泡随之消失。
+
+`cache-control: no-store`；活动随会话事件实时变化，消费者应轮询或在每次 `/whale-girl/events` 信号后重新读取。
+
+## 推导
+
+每条 `session/event` 折叠进每会话视图：
+
+| 事件 | 效果 |
+|---|---|
+| `turn/start` | 活动 `thinking` |
+| `tool/call` | 活动 `tool:<data.name>` |
+| `turn/end`（`reason.kind === 'blocked'`） | 活动 `waiting` |
+| `turn/end`（其他原因） | 活动 `done` |
+| `session/title` | 标题 |
+
+未出现在事件流的会话（插件加载前已存在）由 `sessions.list()` 兜底补录（日志标题、`header.createdAt`）。

--- a/tests/sessions.test.mjs
+++ b/tests/sessions.test.mjs
@@ -1,0 +1,83 @@
+// parseSessionEvent / applySessionView / createSessionView / titleFromLog 单测：
+// GET /whale-girl/sessions 的每会话活动账本（thinking / tool:<name> / waiting / done）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseSessionEvent,
+  createSessionView,
+  applySessionView,
+  titleFromLog,
+} from '../.dsh-plugin/src/sessions.mjs'
+
+const ev = (type, data) => ({ type, seq: 1, time: 1, data })
+
+test('turn/start → thinking', () => {
+  assert.deepEqual(parseSessionEvent(ev('turn/start', { turn: 1 })), { kind: 'activity', value: 'thinking' })
+})
+
+test('tool/call → tool:<name>（bash/pwsh 原样，桌面端映射显示文案）', () => {
+  assert.deepEqual(parseSessionEvent(ev('tool/call', { turn: 1, step: 1, callId: 'c', name: 'bash', arguments: '{}' })),
+    { kind: 'activity', value: 'tool:bash' })
+  assert.deepEqual(parseSessionEvent(ev('tool/call', { turn: 1, step: 1, callId: 'c', name: 'read', arguments: '{}' })),
+    { kind: 'activity', value: 'tool:read' })
+})
+
+test('tool/call 缺 name 返回 null（不推导）', () => {
+  assert.equal(parseSessionEvent(ev('tool/call', { turn: 1 })), null)
+})
+
+test('turn/end blocked → waiting，其余结束原因 → done', () => {
+  assert.deepEqual(parseSessionEvent(ev('turn/end', { turn: 1, reason: { kind: 'blocked' } })),
+    { kind: 'activity', value: 'waiting' })
+  for (const kind of ['completed', 'aborted', 'error', 'max-tokens', 'interrupted']) {
+    assert.deepEqual(parseSessionEvent(ev('turn/end', { turn: 1, reason: { kind } })),
+      { kind: 'activity', value: 'done' }, `reason.kind=${kind}`)
+  }
+})
+
+test('session/title → 标题（不改活动）', () => {
+  assert.deepEqual(parseSessionEvent(ev('session/title', { title: 'whale-girl 二次开发', messageSeqs: [1], source: { kind: 'fallback' } })),
+    { kind: 'title', value: 'whale-girl 二次开发' })
+})
+
+test('非活动事件返回 null（不抛）', () => {
+  assert.equal(parseSessionEvent(null), null)
+  assert.equal(parseSessionEvent('nope'), null)
+  assert.equal(parseSessionEvent({}), null)
+  assert.equal(parseSessionEvent(ev('step/start', { turn: 1, step: 1 })), null)
+  assert.equal(parseSessionEvent(ev('user/message', { text: 'hi' })), null)
+})
+
+test('createSessionView 默认 done + 空标题', () => {
+  assert.deepEqual(createSessionView('s1', 1000), { id: 's1', title: null, activity: 'done', since: 1000 })
+})
+
+test('applySessionView 事件驱动更新（不可变；无变化返回原引用）', () => {
+  const view = createSessionView('s1', 1000)
+  const thinking = applySessionView(view, ev('turn/start', { turn: 1 }))
+  assert.deepEqual(thinking, { id: 's1', title: null, activity: 'thinking', since: 1000 })
+  assert.notEqual(thinking, view)
+  const tool = applySessionView(thinking, ev('tool/call', { turn: 1, step: 1, callId: 'c', name: 'bash', arguments: '{}' }))
+  assert.deepEqual(tool, { id: 's1', title: null, activity: 'tool:bash', since: 1000 })
+  const done = applySessionView(tool, ev('turn/end', { turn: 1, reason: { kind: 'completed' } }))
+  assert.deepEqual(done, { id: 's1', title: null, activity: 'done', since: 1000 })
+  const titled = applySessionView(done, ev('session/title', { title: 'T', messageSeqs: [], source: { kind: 'user' } }))
+  assert.deepEqual(titled, { id: 's1', title: 'T', activity: 'done', since: 1000 })
+  // 无变化事件返回原引用
+  assert.equal(applySessionView(view, ev('step/start', { turn: 1, step: 1 })), view)
+  assert.equal(applySessionView(titled, ev('session/title', { title: 'T', messageSeqs: [], source: { kind: 'user' } })), titled)
+  // 未知事件/异常结构不抛
+  assert.equal(applySessionView(view, null), view)
+})
+
+test('titleFromLog 取最后一个非空标题', () => {
+  const log = [
+    { type: 'session/title', seq: 0, time: 1, data: { title: 'first', messageSeqs: [], source: { kind: 'fallback' } } },
+    { type: 'turn/start', seq: 1, time: 2, data: { turn: 1 } },
+    { type: 'session/title', seq: 2, time: 3, data: { title: 'second', messageSeqs: [1], source: { kind: 'fallback' } } },
+  ]
+  assert.equal(titleFromLog(log), 'second')
+  assert.equal(titleFromLog([]), null)
+  assert.equal(titleFromLog(null), null)
+  assert.equal(titleFromLog([{ type: 'turn/start', seq: 0, time: 1, data: { turn: 1 } }]), null)
+})


### PR DESCRIPTION
## 概述

`GET /whale-girl/sessions` 返回每个运行中会话一行：`{ id, title, activity, since }`。`/whale-girl/state` 只暴露聚合情绪（sessionThink / sessionWait）；外部消费者（如桌面伴侣）需要按会话的明细——哪个会话、标题是什么、此刻在做什么。

## 推导

每条 `session/event` 折叠进每会话视图（新增纯逻辑模块 `.dsh-plugin/src/sessions.mjs`，带单测）：

| 事件 | 效果 |
|---|---|
| `turn/start` | 活动 `thinking` |
| `tool/call` | 活动 `tool:<name>`（bash/pwsh 表示命令行执行中） |
| `turn/end`（`reason.kind === 'blocked'`） | 活动 `waiting` |
| `turn/end`（其他） | 活动 `done` |
| `session/title` | 标题 |

未出现在事件流的会话由 `sessions.list()` 兜底（日志标题 `titleFromLog`、`header.createdAt`）；重启后历史 `session/title` 事件不可重放时，由 `sessionTitle` 服务补全标题。响应 `cache-control: no-store`；会话结束离开列表，消费者的每会话气泡随之消失。

## 文件

- `.dsh-plugin/src/sessions.mjs`（新增，纯逻辑，带单测）
- `.dsh-plugin/index.mjs`（会话账本 + `/sessions` 路由 + 标题兜底）
- `.dsh-plugin/src/routes.mjs`（新增 `SESSIONS_PATH`）
- `tests/sessions.test.mjs`（新增，9 项测试）
- `decisions/implemented/feature/2026-08-15-sessions-endpoint.md`（新增决策记录）
- `docs/sessions-endpoint.md`（新增契约文档）

## 与 #1 的关系与致谢

本端点是 [xiaoshihou514](https://github.com/xiaoshihou514) 在 #1 引入的外部消费者契约（`/whale-girl/state`、`/presence`、`/assets/*`）的按会话补充：/state 提供聚合情绪，/sessions 提供每会话明细，二者共同支撑桌面伴侣等消费者。本 PR 基于 vlln `main`，独立于 #1（只需既有 `session/event` 事件流），两者谁先合并均可。桌面伴侣应用见 github.com/DeeJ6126/whale-girl-desktop，同时消费两者。

## 备注

- 本地门禁 8/11 通过。`verify-decisions` 与 `verify-spec-states` 在干净 `main` 上同样失败（预存问题：旧决策记录缺 `Status` 行、`docs/sprites-spec.md` 缺状态总表标题）；`check-generated` 需要 `esbuild`（全新 checkout 未 `pnpm install`）。
