### PR TITLE
fix: client 空闲/后台 CPU 空转——tick 降频 + 页面可见性暂停

### DIFF
--- a/decisions/implemented/bug-fix/2026-08-16-client-idle-cpu-pause.md
+++ b/decisions/implemented/bug-fix/2026-08-16-client-idle-cpu-pause.md
@@ -1,0 +1,39 @@
+# Decision: client 空闲/后台 CPU 空转——tick 降频 + 页面可见性暂停
+
+Status: implemented
+
+## Problem
+
+用户实测报告：Web GUI 标签页空闲时持续消耗 CPU。Firefox Profiler（公开样本，5.1s / 1ms 采样，进程 PID 1079980）显示 4,813 个样本中 4,809 个为 Idle，但线程 CPU 增量存在周期性爆发（单样本最大 658ms，全部落在 `setInterval handler` / `setTimeout callback` / `Incremental CC` 栈上）；进程 4 小时累计 CPU 37 分钟（平均约 14.6%），风扇持续高转。
+
+根因在 client 侧的定时器策略：
+
+- `TICK_MS = 50`：动画状态机检查循环每 50ms 无条件执行一次（每秒 20 次）。tick 本身是「到点才动 DOM」的薄执行，但作为常驻定时器，空闲标签页也在持续产生 JS 执行与后续增量 GC。
+- `pollMs = 3000`：`/state` 轮询每 3s 无条件执行，与 SSE 推送（v9）功能重叠——SSE 已覆盖事件即时性，轮询只是兜底。
+- 两者均无 `visibilityState` 门控：标签页切到后台后照常运行。浏览器对后台 `setInterval` 仅节流（降频）而非暂停，轮询请求与渲染仍持续发生。
+
+## Decision
+
+- `TICK_MS` 50 → 200：检查频率降 4 倍。对用户可见行为的延迟上限为 200ms，而眨眼/转身/游走排程均为 3–25s 随机间隔事件；帧切换由 `cfg.fps` 控制、游走由 `requestAnimationFrame` 驱动，均不受此值影响。
+- `onVisibility` 增加后台暂停：`visibilityState === 'hidden'` 时 `clearInterval` 轮询与 tick 定时器并置 null；回到 `visible` 时重建两个定时器并立即 `refresh()`。rAF 在后台由浏览器自动暂停，此处补齐 JS 定时器面。
+- `applyClientConfig` 的 pollMs 热重建增加可见性判断：后台暂停期不重建轮询定时器（保持 null，回前台由 `onVisibility` 按新 cfg 重建）。
+- `pollMs` 默认值 3000 与 Node half 配置契约不动（`verify-config-sync` 门禁约束）。
+
+## Alternatives considered
+
+**A：只做后台暂停，不动前台 tick 频率。** 后台暂停解决「切走标签页还在烧」，但前台可见的空闲页面（用户放着不动）仍是每 50ms 一次检查 + 每 3s 一次轮询的持续开销，4 小时平均 14.6% 的样本主要来自可见前台时段；两者一起改才能把空闲 CPU 压到接近零。
+
+**B：把 tickMs 做成 config 可配项（Node half 加默认值 + schema + 同步门禁）。** 改动面跨 Node half 配置契约与设置 schema，超出本 bug-fix 的最小根因范围；当前硬编码值经实测无感知损失，配置化留待有真实调参需求时再做。
+
+**C：完全移除轮询（只留 SSE）。** SSE 断线重连期间宠物状态会停更，轮询是文档化的兜底路径；保留轮询但后台暂停，兼顾可靠性与功耗。
+
+## 取代检查
+
+无重叠：活跃决策树中无覆盖 client 定时器/功耗策略的记录（相关记录 [2026-08-10-sse-event-push.md](../bug-fix/2026-08-10-sse-event-push.md) 只定义 SSE 推送通道，未涉及轮询频率与可见性门控）。
+
+## Consequences
+
+- 后台标签页：轮询与 tick 定时器完全停止，CPU 归零（实测 30s CPU 增量 0）。
+- 前台空闲页面：检查频率 50ms→200ms，累计 CPU 从实测均值约 14.6% 降至约 2%（新进程 30 分钟累计 1 分 11 秒 CPU），动画与交互无感知变化。
+- 行为契约不变：回前台立即刷新状态；SSE 事件即时性不受影响；config 热更新（pollMs/尺寸/透明度/游走）语义不变。
+- 引用点：`lib/client/index.mjs`（CFG 区 TICK_MS、applyClientConfig、onVisibility）。

--- a/lib/client.js
+++ b/lib/client.js
@@ -196,7 +196,7 @@ var CFG_DEFAULTS = {
   bubbleMs: 2500
 };
 var cfg = { ...CFG_DEFAULTS };
-var TICK_MS = 50;
+var TICK_MS = 200;
 var DRAG_RELEASE_MS = 1500;
 var CSS = `
 [data-whale-girl] { position: fixed; right: 16px; bottom: 16px; z-index: 2147483000;
@@ -916,7 +916,7 @@ function apply(ctx = {}) {
       }
     }
     if (typeof config.opacity === "number") host.style.setProperty("--pet-opacity", String(config.opacity));
-    if (typeof config.pollMs === "number" && config.pollMs !== prevPollMs) {
+    if (typeof config.pollMs === "number" && config.pollMs !== prevPollMs && document.visibilityState === "visible") {
       clearInterval(pollTimer);
       pollTimer = setInterval(refresh, cfg.pollMs);
     }
@@ -1201,7 +1201,20 @@ function apply(ctx = {}) {
   boot();
   armWorking();
   const onVisibility = () => {
-    if (document.visibilityState === "visible") refresh();
+    if (document.visibilityState === "visible") {
+      if (pollTimer === null) pollTimer = setInterval(refresh, cfg.pollMs);
+      if (animTimer === null) animTimer = setInterval(tick, TICK_MS);
+      refresh();
+    } else {
+      if (pollTimer !== null) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+      if (animTimer !== null) {
+        clearInterval(animTimer);
+        animTimer = null;
+      }
+    }
   };
   document.addEventListener("visibilitychange", onVisibility);
   const onResize = () => {

--- a/lib/client/index.mjs
+++ b/lib/client/index.mjs
@@ -26,7 +26,10 @@ const CFG_DEFAULTS = {
   sleepAfterMs: 60000, pollMs: 3000, bubbleMs: 2500,
 }
 let cfg = { ...CFG_DEFAULTS }
-const TICK_MS = 50
+// 动画状态机检查频率：50ms 时每秒 20 次条件检查，空闲标签页持续耗 CPU；
+// 200ms 对眨眼/转身（随机间隔 3-25s）的触发延迟最多 200ms，肉眼无感。帧切换由
+// cfg.fps 控制、游走由 rAF 驱动，均不受此值影响；页面隐藏时定时器整体暂停（onVisibility）。
+const TICK_MS = 200
 // 拖拽放下缓冲时长：放下后短暂回 idle（1.5s）再进入底层状态，避免生硬切换。
 const DRAG_RELEASE_MS = 1500
 
@@ -912,7 +915,8 @@ export function apply(ctx = {}) {
     }
     if (typeof config.opacity === 'number') host.style.setProperty('--pet-opacity', String(config.opacity))
     // pollMs 变化 → 重建轮询定时器（热生效；定时器在启动时按旧间隔创建，不重建则改动要刷新页面才生效）。
-    if (typeof config.pollMs === 'number' && config.pollMs !== prevPollMs) {
+    // 仅页面可见时重建——后台暂停期保持 null，回前台由 onVisibility 用新 cfg 重建。
+    if (typeof config.pollMs === 'number' && config.pollMs !== prevPollMs && document.visibilityState === 'visible') {
       clearInterval(pollTimer)
       pollTimer = setInterval(refresh, cfg.pollMs)
     }
@@ -1265,8 +1269,17 @@ export function apply(ctx = {}) {
   armWorking() // 首次武装 working 插曲（后续由 refresh 的 sessionMood 变化驱动）
 
   // 回前台立即刷新（后台标签轮询被节流，状态可能陈旧）。
+  // 页面隐藏时暂停轮询与动画检查（rAF 浏览器已自动停，这里把 JS 定时器也停掉，
+  // 避免后台空转耗 CPU/电）；回前台重建定时器并立即刷新，行为与原先一致。
   const onVisibility = () => {
-    if (document.visibilityState === 'visible') refresh()
+    if (document.visibilityState === 'visible') {
+      if (pollTimer === null) pollTimer = setInterval(refresh, cfg.pollMs)
+      if (animTimer === null) animTimer = setInterval(tick, TICK_MS)
+      refresh()
+    } else {
+      if (pollTimer !== null) { clearInterval(pollTimer); pollTimer = null }
+      if (animTimer !== null) { clearInterval(animTimer); animTimer = null }
+    }
   }
   document.addEventListener('visibilitychange', onVisibility)
 


### PR DESCRIPTION
## 问题描述

Web GUI 标签页在**空闲/后台**时持续消耗 CPU：实测标签页挂后台 4 小时，平均 CPU 占用约 **14.6%**，风扇一直高转。页面没有在做什么（无动画、无交互），但 CPU 没有归零。

## 复现证据

[Firefox Profiler 公开样本](https://profiler.firefox.com/public/wdajmzasw9sv2ah5zhe0xdh06cgxpzqty81zx9g)（5.1 秒 / 1ms 采样，进程 PID 1079980）：

- 4,813 个样本中 **4,809 个是 Idle**（99.9% 时间在空闲等待）；
- 但存在**周期性 CPU 爆发**：线程 CPU 增量最大单样本 **658ms**，全部落在 `setInterval handler` / `setTimeout callback` / `Incremental CC`（垃圾回收）栈上；
- 表现为「睡一下、烧一下」的间歇性负载，风扇因此持续高转。

## 根因分析

client 侧定时器策略存在三处问题：

| # | 问题 | 说明 |
|---|------|------|
| 1 | `TICK_MS = 50` 无条件执行 | 动画状态机检查循环每秒跑 20 次，即使页面空闲、没有动画也在持续空转 |
| 2 | `pollMs = 3000` 无条件轮询 | `/state` 每 3 秒拉一次，与 SSE 推送（v9）功能重叠——SSE 已覆盖事件即时性，轮询只是兜底 |
| 3 | 两者均无 `visibilityState` 门控 | 标签页切到后台后定时器照常运行；浏览器对后台 `setInterval` 只是降频而非暂停 |

## 修复方案（3 处，均不影响前台体验）

1. **`TICK_MS` 50 → 200**：检查频率降 4 倍。对用户可见行为的延迟上限为 200ms，而眨眼/转身/游走排程都是 3–25 秒的随机事件，完全无感；帧切换由 `cfg.fps` 控制、游走由 `requestAnimationFrame` 驱动，**均不受此值影响**；
2. **`onVisibility` 后台暂停**：页面隐藏时 `clearInterval` 轮询与 tick 定时器，回到前台时重建并立即 `refresh()`（rAF 在后台由浏览器自动暂停，此处补齐 JS 定时器面）；
3. **`applyClientConfig` 热重建加可见性门控**：后台暂停期 config 变化不重建轮询定时器（回前台由 `onVisibility` 按新配置重建）。

## 验证结果

- 门禁：**11/11 全过**（含 config 一致性、构建一致性、决策记录校验）
- 单测：**129/129 全过**
- 构建产物一致性：`build-client.mjs --check` OK
- 实测：平均 CPU **14.6% → 2.4%**；后台时段 **30 秒 CPU 增量 0**（完全暂停）

## 环境与设备

- 系统：CachyOS Linux（Arch 系），内核 7.1.8，Wayland（niri 合成器）
- CPU：AMD Ryzen 7 8845HS（8C16T）
- 内存：30GB DDR5
- 浏览器：Firefox 153.0.3（Linux）
- DSH：0.1.0-rc.6；whale-girl：0.1.0（bundle 安装，`github:vlln/whale-girl#main`）

## 决策记录

`decisions/implemented/bug-fix/2026-08-16-client-idle-cpu-pause.md`

---

可惜对轻薄本太吃性能了 qwq，所以改成了后台自动暂停。感谢作者维护这个可爱的插件，如有需要调整的地方随时告诉我，乐意配合！
