### PR TITLE
feat: add desktop companion for whale-girl (render pet on OS desktop)

### DIFF
--- a/decisions/implemented/feature/2026-08-16-desktop-companion.md
+++ b/decisions/implemented/feature/2026-08-16-desktop-companion.md
@@ -1,0 +1,53 @@
+# Decision: 桌面伴侣作为独立外部消费者（desktop/）
+
+Status: implemented
+
+> 承接 [GUI 内宠物架构（A 模式）](2026-08-08-in-gui-pet-architecture.md) 的 B' 方向考量——
+> 该决策把「OS 原生常驻渲染」列为 future feature；本决策将其落地为独立 `desktop/` 应用，
+> 不改动 A 模式的插件本体。
+
+## Problem
+
+A 模式宠物只在 DSH Web GUI 页面内可见、依赖页面焦点；用户不便把鲸鱼娘「带到桌面」独立陪伴。
+需要一个**不修改插件本体**的原生桌面渲染方案，避免双代码/双账本。
+
+## Decision
+
+新增 **`desktop/` 独立应用**（Node.js ESM + Electron 可选渲染壳），作为**外部 HTTP 消费者**：
+
+- **不改动 whale-girl 本体**：不碰 `lib/`、`lib/client.js`、`lib/assets/`、`tests/`、`scripts/gates/`。
+- **消费既有公开端点**：`GET /state`（非消费式快照）、`GET /events`（SSE 即时刷新）、
+  `POST /presence`（心跳上下线）、`POST /interact`（feed/play）、`GET /config`、`GET /assets/*`
+  （manifest + sprite dataURL 经 IPC 喂给 renderer，renderer 零网络、无 CORS 面）。
+- **presence 契约**：每 15s `{online:true}`（whale-girl `PRESENCE_TTL_MS=45s`，余量 3 次心跳）；
+  退出 `{online:false}`；崩溃靠 TTL 45s 自动过期回网页端。桌面在线时网页端隐藏宠物，避免双宠。
+- **状态机/调度**：对齐 `lib/client/logic.mjs` 的 `pickState` 优先级（burst > 互动瞬发 > wait >
+  回合完成 > working 插曲 > think > joy > sleep > walk > idle），纯 Node、无 DOM，复用同一状态集合。
+- **渲染**：Electron 透明置顶窗 Canvas 帧播放；点击投喂/拖拽换位、资历角标。
+- **headless**：`--headless` 只跑心跳+轮询+SSE（CI / 无桌面环境自测）。
+
+架构边界：
+
+- 桌面端**只写**两个公开端点（presence 心跳、interact 乐趣），**绝不写账本**（XP/称号由
+  whale-girl 独占，保持积累不变量）。
+- 两个代码库边界清晰：`desktop/` 自带 `package.json`（独立 app），不进插件的
+  `bundles/files` 白名单，`dsh plugin` 安装流程不受影响。
+
+## Alternatives considered
+
+- **并入插件 client half（C 模式）**：在 bundle 里同时渲染网页与桌面，会撑大客户端、
+  混入平台原生依赖，且 desktop 渲染与网页渲染是不同生命周期，单一 bundle 难兼顾。
+- **只做心跳+托盘、无渲染（精简 MVP）**：落地快但无化身，弱交互；本实现保留其核心（can run
+  headless）并叠加渲染壳，两全。
+- **Tauri/Electron 原生重写状态机**：脱离 whale-girl 契约，风险高、难回滚；本实现严格复用
+  whale-girl 端点与状态集合，集成成本最低。
+
+## Consequences
+
+- 桌面端生命周期独立：启动/退出/崩溃不影响插件本体；崩溃时经 presence TTL 自动恢复网页宠物。
+- 维护成本：两份代码（插件 + desktop/）需同步契约；本实现以 `DESIGN.md`+`BUILD-RUN.md` 记录
+  契约，并以端到端测试锁住（`/state /presence /interact /config /manifest /sprite`）。
+- 渲染层零网络：manifest/sprite 由 desktop 主进程拉取转 dataURL，renderer 无 fetch/CORS，
+  与 whale-girl 的 assets 净化路径解耦。
+- 安全面：`/presence`、`/interact` 本地调用不带 Origin/Sec-Fetch-Site → `isCrossOrigin` 判定
+  同源放行；端到端测试覆盖。

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+shot.png

--- a/desktop/BUILD-RUN.md
+++ b/desktop/BUILD-RUN.md
@@ -1,0 +1,146 @@
+# whale-girl-desktop — 构建与运行指南
+
+把 DSH Web GUI 内的桌面宠物插件 **whale-girl** 渲染到操作系统桌面，作为独立伴侣进程常驻屏幕，
+并实时消费 whale-girl 的状态/事件。网页端在桌面伴侣在线时自动隐藏自己的宠物，避免"双宠物"。
+
+- 技术方案与契约：见 [DESIGN.md](./DESIGN.md)（t1 调研输出）
+- 输出目录：`C:\Users\12258\whale-girl-desktop\`
+- 集成方式：**外部 HTTP 消费者**，不改 whale-girl 本体（DESIGN §2.1 决策）
+
+---
+
+## 1. 环境要求
+
+- Node.js **≥18**（本机 v24.11.1 验证通过），npm ≥9
+- DSH web 服务运行在 `http://127.0.0.1:3080`（whale-girl 插件已装）
+- 桌面渲染（Electron）需图形界面；纯核心可 headless 跑（`--headless`）
+
+## 2. 安装依赖
+
+```sh
+cd C:\Users\12258\whale-girl-desktop
+npm install
+```
+
+> ⚠️ Electron 二进制下载在国内网络可能超时。若 `npm install` 后
+> `node_modules\electron\dist\electron.exe` 缺失，用国内镜像补下载：
+> ```powershell
+> $env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
+> node node_modules/electron/install.js
+> ```
+> （本机即以此方式成功下载 v43.4.0。）
+
+## 3. 运行
+
+### 桌面模式（推荐）——画宠物到桌面
+
+```sh
+npm run start:desktop      # electron .，透明置顶窗渲染宠物
+```
+
+启动后右下角出现鲸鱼娘宠物（透明窗、置顶、点击可投喂/玩耍、拖拽可换位）。
+退出：关闭宠物窗口 / 托盘退出 / 进程关闭 → 自动发 `POST /presence {online:false}`，网页宠物立即恢复。
+
+### Headless 模式（核心自测 / 无桌面环境）
+
+```sh
+npm run start:headless     # node lib/index.mjs --headless
+```
+
+只跑心跳 + 状态轮询 + SSE，不弹窗口，打日志。用于自测 / CI / 服务器。
+
+### 其他启动参数
+
+```sh
+node lib/index.mjs --base-url=http://IP:PORT   # 指向非本机 DSH
+node lib/index.mjs --poll-ms=5000              # 轮询间隔
+node lib/index.mjs --no-presence               # 不接管在场上线（不隐藏网页宠物）
+node lib/index.mjs --no-render                 # 同 --headless
+```
+
+环境变量：`WHALE_GIRL_BASE_URL` / `WHALE_GIRL_POLL_MS` / `WHALE_GIRL_HEARTBEAT_MS`。
+
+## 4. 测试
+
+```sh
+npm test
+```
+
+`node --test test/**/*.test.mjs`，**26 用例全绿**，覆盖：
+- 状态机（`pickState`/`pickAnimation`）确定性映射：burst 优先级 / wait / think /
+  celebrate / sleep / transient
+- 本地调度（`scheduler`）：空闲→入睡、活跃重置、interact eat/play+joy
+- SSE 客户端解析与重连（本地 http server 模拟）
+- **端到端契约**（连真实 3080）：/state /config /manifest /presence /interact /sprite 形状
+  + `createCompanion` 全链路（心跳上线 → stop 下线）
+
+> 端到端用例会短暂把 `companionOnline` 置 true 再置 false，测试结束自动恢复，无副作用。
+
+## 5. 目录结构
+
+```
+whale-girl-desktop/
+├─ DESIGN.md              # 设计方案（t1）
+├─ package.json           # ESM，main: lib/index.mjs；脚本 start/start:headless/start:desktop/test
+├─ lib/
+│  ├─ index.mjs           # 入口：headless 还是 Electron 渲染
+│  ├─ src/config.mjs      # 本地运行参数（BaseURL、pollMs、heartbeatMs）
+│  ├─ client/
+│  │  ├─ http.mjs         # fetch 封装：/state /interact /config /sessions /presence /assets
+│  │  ├─ events.mjs       # SSE 客户端（fetch 流式，断线重连）
+│  │  ├─ companion.mjs    # 核心引擎：心跳 + 轮询 + SSE + 调度 + 互动
+│  │  ├─ scheduler.mjs    # 本地节奏：睡眠/游走/working 插曲/interact 瞬发
+│  │  ├─ state.mjs        # 状态机：activity→动画意图（对齐 whale-girl pickState）
+│  │  ├─ state-names.mjs  # 15 状态权威集合
+│  │  ├─ behaviors.mjs    # working 节奏/睡醒/醒觉纯函数
+│  │  └─ utils.mjs        # 路由拼接 + 日志
+│  └─ render/
+│     └─ window.mjs       # Electron main：透明置顶窗 + IPC 数据通道
+├─ render/
+│  ├─ index.html          # 渲染页（透明背景 + 气泡 + 角标）
+│  ├─ preload.cjs         # 最小安全 IPC bridge
+│  └─ renderer.js         # Canvas 帧播放器 + 内容 bbox 点击穿透 + 拖拽
+└─ test/contract.test.mjs # 状态机/调度/SSE + 端到端契约测试
+```
+
+## 6. 已实现功能（P0 + P1 核心）
+
+| 项 | 状态 | 说明 |
+|---|---|---|
+| **P0-1** presence 心跳 | ✅ | 每 15s `POST /presence {online:true}`；退出 `{online:false}`；崩溃 45s 自动过期 |
+| **P0-2** 状态轮询 | ✅ | 每 3s `GET /state`，解析 pet + activity |
+| **P0-3** 事件即时刷新 | ✅ | SSE `/events`，事件到即刷新——完成/失败/会话/turn 即时反映 |
+| **P0-4** 桌面渲染 | ✅ | Electron 透明置顶窗 + Canvas 帧播放（manifest 帧布局） |
+| **P0-5** 退出清理 | ✅ | 关窗/退出 → 显式下线 |
+| **P1-1** 点击互动 | ✅ | 点宠物 → feed/play 轮换，气泡回话 |
+| **P1-2** 资历角标 | ✅ | Lv./任务数/称号 + 思考中标记 |
+| **P1-4** 配置跟随 | ⏳ | 结构预留（remoteConfig 已读，size 跟随 P2 完成） |
+
+## 7. 关键实现说明 / 踩坑记录
+
+1. **Electron ESM main 顶层 await 陷阱**：入口 `lib/index.mjs` 若在模块顶层 `await runDesktop()`
+   （其内 `await app.whenReady()`），会阻塞 Electron 事件循环导致 `ready` 永不触发（窗口不建、
+   无心跳）。修法：入口用 `process.nextTick(() => runDesktop(...).catch(...))` fire-and-forget，
+   `runDesktop` 内部照常 `await app.whenReady()`（见 window.mjs）。
+2. **确定性时间 bug**：状态机 `STATE_TABLE` 的 burst/joy/celebrate 谓词最初用 `Date.now()`，
+   测试传固定 `now` 时全失效（26 用例 3 失败）。改为读注入的 `c.now` 后全绿。
+3. **interact 顺序**：`feed`/`play` 瞬发应覆盖醒觉（wake 只用于拖拽放下），调整了
+   `applyInteraction` 顺序对齐 whale-girl 上游。
+4. **Electron 二进制下载**：国内网络默认 CDN 超时，改用 `npmmirror.com` 镜像成功。
+5. **CSRF 面**：桌面本地 HTTP 调用不带 Origin/Sec-Fetch-Site → whale-girl `isCrossOrigin`
+   判定为同源，`/presence`、`/interact` 放行（已验证，见测试）。
+
+## 8. 验收对照（DESIGN §7）
+
+1. ✅ 桌面进程启动 → `/state.companionOnline === true`，网页端隐藏宠物
+   （实测 `companionOnline: true`，窗口可见宠物）
+2. ✅ 每 15s 心跳；进程退出（含 Ctrl+C 经 SIGTERM）→ 显式 `{online:false}`，网页宠物即恢复；
+   强制杀死则 45s TTL 过期自动恢复
+3. ✅ 事件即时性：SSE 事件 → 立即 `/state`，1 次往返出动画（任务完成 → celebrate）
+4. ✅ 只做外部 HTTP 消费者，账本（XP/称号）由 whale-girl 独占，本程序不写任何账本面
+
+---
+
+### 已知限制 / 后续（P2）
+- `size` 配置跟随、开机自启、多屏位置记忆为 P2 预留（renderer 已支持，主进程未接牢）。
+- 点击穿透基于内容 bbox 开关，未做逐帧窗口收缩（透明边距可能挡鼠标，P2 增强）。

--- a/desktop/DESIGN.md
+++ b/desktop/DESIGN.md
@@ -1,0 +1,226 @@
+# whale-girl 桌面伴侣 — 设计方案（DESIGN.md）
+
+> 版本：v1 · 状态：方案设计 · 归属任务：t1
+> 工作区：`C:\Users\12258\whale-girl-desktop\`
+> 描述对象：为 DSH Web GUI 内的桌面宠物插件 whale-girl 开发一个**独立桌面伴侣应用**，
+> 使其化身显示在桌面上（宠物跑到屏幕角落、常驻），并满足对 whale-girl 既有端点的消费契约。
+
+---
+
+## 1. 背景与目标
+
+whale-girl 是一款 DSH Web GUI 插件（`C:\Users\12258\.dsh\profiles\web\node_modules\whale-girl\`），
+提供网页内自渲染的桌面宠物（QQ 宠物形态）。宠物只有在浏览器开着 DSH 页面时可见、依赖页面焦点，
+用户不便将其"带到桌面"独立陪伴。
+
+**目标**：构建一个独立的**桌面伴侣进程**（非浏览器页面），把 whale-girl 的化身渲染到操作系统桌面，
+常驻于屏幕，并实时消费 whale-girl 的状态/事件。网页端在桌面伴侣在线时**隐藏自己的宠物**，
+避免"双宠物"。
+
+**约束与前提（已验证的环境事实）**：
+- whale-girl Node half 注册的路由前缀是 `/whale-girl`（单一来源 `lib/src/routes.mjs`）。
+- 端点集合：`GET /whale-girl/state`、`POST /whale-girl/interact`、`GET /whale-girl/config`、
+  `GET /whale-girl/assets/*`、`/whale-girl/assets/manifest.json`、`GET /whale-girl/events`（SSE）、
+  `POST /whale-girl/presence`、`GET /whale-girl/sessions`。
+- DSH web 服务在 `http://127.0.0.1:3080`。
+- presence 契约（`lib/src/presence.mjs`）：`PRESENCE_TTL_MS = 45s`，桌面端每 15s `POST /presence {online:true}` 续命；
+  `{online:false}` 立即下线，网页端宠物恢复显示。
+- 状态是**非消费式快照**（`/state` 返回 `pet` + `activity`，可被 Web 与外部伴侣同时观察）。
+- 无第三方渲染依赖：whale-girl 是 sprite sheet 帧播放（浏览器 Canvas）。
+
+---
+
+## 2. 技术选型
+
+### 2.1 运行时与语言
+采用 **Node.js（≥18，ESM）+ Electron 的可选外壳**，拆成两层：
+
+| 层 | 技术 | 理由 |
+|---|---|---|
+| 核心伴侣逻辑 | Node.js ESM（`lib/`） | 复用 whale-girl 相同的 ESM 形态；纯 HTTP 客户端，零 GUI 依赖，可在 headless 下跑通心跳 |
+| 桌面渲染外壳 | Electron（可选项） | 让 sprite 播到真实桌面（透明窗口、置顶）；Electron 自带 Canvas + 透明 frameless 窗口 |
+| 状态/事件消费 | 原生 `fetch` + `EventSource` | 复用 whale-girl 的 `/state` 轮询 + `/events` SSE 通道 |
+
+> **决策要点**：**不修改 whale-girl 本体**。桌面伴侣只做**外部 HTTP 消费者**，
+> 通过 `/state`、`/events`、`/presence` 等既有公开端点交互 —— 这是风险最低、可回滚的集成方式。
+
+### 2.2 渲染方案二选一（外壳内部）
+1. **Electron 透明窗 + Canvas 帧播放**：沿用 whale-girl sprite 资产，逐帧 `drawImage`。
+   - 优点：与网页端一致、可加点击投喂交互；缺点：打包体积大。
+2. **原生无壳（仅 Node）+ 系统托盘/快捷键**：不做真实桌面绘制，只做心跳 + 状态回读，
+   在托盘提示/通知里展示宠物状态。
+   - 优点：极轻；缺点：无化身、交互弱。
+
+**推荐**：优先做**方案 2 的完整版 + 方案 1 的渲染**——即 Electron 透明窗负责画宠物，Node 核心负责
+状态与心跳。若首版要最快落地，可先交付**方案 2（无窗、纯心跳 + 托盘）**作为 MVP，再升级到渲染。
+
+### 2.3 依赖
+- Node 侧：`node:fs` / `node:path` / `node:http`（或直接 `fetch`）——**不新增第三方运行时依赖**。
+- Electron 侧（可选）：`electron`。
+- 测试：`node --test`（与 whale-girl 仓库同风格）。
+
+---
+
+## 3. 通信契约（桌面伴侣 ⇄ whale-girl）
+
+> 前缀 `/whale-girl`；基础 `BaseURL = http://127.0.0.1:3080`。
+
+### 3.1 轮询状态 —— `GET /whale-girl/state`
+- 方法：`GET`，禁缓存（`cache-control: no-store`）。
+- 响应体：
+  ```jsonc
+  {
+    "apiVersion": <number>,
+    "pet": {
+      "level": <number>,
+      "xp": <number>,
+      "stats": { "tasksDone": 0, "failures": 0, "sessions": 0, "activeMs": 0, "firstSeenAt": <number|null> },
+      "titles": [<string>],
+      "memory": [<string>],
+      "updatedAt": <number>
+    },
+    "activity": {
+      "name": "idle|working|welcome|celebrate|error|disappointed",
+      "until": <number>,
+      "sessionThink": <bool>,
+      "sessionWait": <bool>,
+      "turnCompleted": <bool>,
+      "turnCompletedUntil": <number>
+    },
+    "configRevision": <number>,
+    "companionOnline": <bool>   // 是否已有桌面伴侣在线（桌面端应观察，避免自举冲突）
+  }
+  ```
+- **非消费式**：`activity` 带 `until` 绝对截止，多个消费者（网页 + 桌面）同时观察同一回合完成，互不干扰。
+
+### 3.2 即时事件 —— `GET /whale-girl/events`（SSE）
+- `Content-Type: text/event-stream`；`retry: 3000`；心跳 25s `: ping` 注释行。
+- 事件行：`data: {"type":"event"}\n\n`——收到后客户端应**立即重新 `/state`**（把延迟从 pollMs 降到单次往返）。
+- 触发点：回合完成/失败、会话启动、请求错误、turn 边沿（think 陪伴/回合完成）等。
+- **桌面端用法**：`EventSource` 订阅；`onmessage` 触发 `refreshState()`。
+- **兜底**：SSE 断线时靠 `/state` 轮询（默认 3s）保证宠物照常。
+
+### 3.3 在场心跳 —— `POST /whale-girl/presence`
+- 请求体：`{ "online": true }`（续命窗口 45s）；每 **15s** 发送一次。
+- 下线/退出：`{ "online": false }` 立即下线；崩溃/进程结束则心跳过期（45s）自动下线，网页端宠物恢复。
+- 响应：`{ "online": <bool> }`。
+- **语义**：显示层写面，无账本影响；与 `/interact` 同级安全面（跨源校验 + 请求体上限 1KB）。
+- **重要**：心跳期间的 `/state` 的 `companionOnline = true` → 桌面端应据此确认"自己生效"；
+  网页端（配置 `enabled`）收到 `companionOnline=true` 时**隐藏网页宠物**，避免双宠物。
+
+### 3.4 互动 —— `POST /whale-girl/interact`
+- 请求体：`{ "action": "feed" | "play" }`。需**同源 CSRF 校验通过**（见 3.6）。
+- 响应：`{ "pet": <state>, "reply": "<回话>" }`。
+- 纯乐趣、零负反馈：状态不变。
+
+### 3.5 只读配置 —— `GET /whale-girl/config`
+- 返回 `{ "config": { ... }, "revision": <number> }`。桌面端按 `configRevision` 判断是否需要重应用体验参数。
+
+### 3.6 每会话活动 —— `GET /whale-girl/sessions`
+- 返回数组：`[{ id, title, activity: "thinking|tool:<name>|waiting|done", since }]`。
+- 供桌面伴侣的消息框展示"当前 DSH 在做任务 / 在等你"。
+
+### 3.7 资产 —— `GET /whale-girl/assets/*`
+- sprite sheet 与 manifest：`GET /whale-girl/assets/manifest.json`（帧布局、尺寸、动画序列）。
+- 桌面端拉取后本地帧播放；`cache-control: no-cache`，替换同名 sheet 后须重新校验（避免旧图）。
+
+### 3.8 安全面（契约红线）
+- `/interact`、`/presence`：跨源请求被拒（`Sec-Fetch-Site` 非 `same-origin`/`none` 且不带 Origin → 403）。
+  **桌面端本地 HTTP 调用通常不带 Origin / Sec-Fetch-Site，应被识别为同源；如被拒，需对齐 Origin 语义，
+  由桌面端显式设置正确请求头（走 localhost 同源语义）。**（实现时验证）
+- 请求体上限 1KB（`/interact`、`/presence`）。
+
+### 3.9 时序
+```
+Desktop进程启动
+  ├─ 立即 POST /presence {online:true}          // 宣告在线
+  ├─ 启动 15s 心跳定时器 → POST /presence {online:true}
+  ├─ 启动刷新循环：fetch /state（每 3s）+ EventSource /events（即时触发）
+  ├─ 按需拉 assets manifest + sprite → 桌面渲染
+  └─ 退出：POST /presence {online:false} → 进程结束
+网页端                                  同时
+  ├─ /state.companionOnline === true → 隐藏网页宠物（避免双宠）
+  └─ /state.companionOnline === false → 恢复网页宠物
+```
+
+---
+
+## 4. 功能清单
+
+### 4.1 P0 —— 核心（MVP，必须）
+- **P0-1 在场心跳**：每 15s `POST /presence {online:true}`；退出时 `{online:false}`；崩溃自动过期。
+  （使网页端隐藏宠物，桌面化身成为"唯一宠物"）
+- **P0-2 状态轮询**：每 3s（`pollMs`）`GET /state`，解析 `pet` + `activity`。
+- **P0-3 事件即时刷新**：`EventSource /events`，收到事件立即重新 `/state`。
+- **P0-4 桌面渲染（Electron）**：按 `manifest.json` 播放 sprite 帧；activity →
+  对应动画倾向（idle/working/welcome/celebrate/error/disappointed）；宠物一角常驻、透明置顶。
+- **P0-5 登出/关闭清理**：Ctrl+Q / 托盘退出 → 显式下线 + 释放。
+
+### 4.2 P1 —— 体验增强
+- **P1-1 点击互动**：点击宠物 → `POST /interact {action:feed/play}`，展示气泡回话。
+- **P1-2 资历角标**：显示 `Lv.${level}`、XP、已解锁称号；结算回合完成 `celebrate`。
+- **P1-3 会话状态显示**：消费 `/sessions`，托盘/气泡提示"DSH 思考中 / 等待你批准"。
+- **P1-4 配置跟随**：消费 `/config`，按 `configRevision` 跟随 size/opacity/窗口时长等。
+
+### 4.3 P2 —— 进阶
+- **P2-1 崩溃自恢复**：监听进程退出信号，非正常退出也兜底自然过期不污染。
+- **P2-2 多屏/工作区**：记忆上次位置，开机自启（系统托盘）。
+- **P2-3 主题/淡入淡出**：透明度动画、过节彩蛋。
+
+> 交付顺序：P0（心跳+轮询+SSE+渲染）→ P1 → P2。
+
+---
+
+## 5. 目录结构（建议）
+
+```
+C:\Users\12258\whale-girl-desktop\
+├─ DESIGN.md                 # 本文件
+├─ package.json              # ESM, main: lib/index.mjs
+├─ lib/
+│  ├─ index.mjs              # 桌面伴侣入口：组装 client + heartbeat + render
+│  ├─ client/
+│  │  ├─ http.mjs            # fetch 封装：/state /interact /config /sessions /presence
+│  │  ├─ events.mjs          # EventSource 订阅 + 重连
+│  │  ├─ state.mjs           # 状态机：activity → 动画意图映射
+│  │  └─ heartbeat.mjs       # 15s presence 心跳 + 退出清理
+│  ├─ render/
+│  │  ├─ window.mjs          # Electron 透明置顶窗
+│  │  └─ sprite.mjs          # manifest 解析 + 帧播放
+│  └─ src/
+│     └─ config.mjs          # 桌面端本地配置（BaseURL、pollMs 等）
+├─ assets/                   # （可选）本地图标/托盘图
+└─ test/
+   └─ contract.test.mjs      # 校验本端点到 whale-girl 契约的测试
+```
+
+---
+
+## 6. 风险与对策
+
+| 风险 | 影响 | 对策 |
+|---|---|---|
+| `/presence` 或 `/interact` 因跨源判定拒绝本地调用 | 心跳失败、桌面化身上不了线 | 本地调用对齐同源语义；验证请求头；必要时为桌面端走受信 Origin 白名单（不放宽安全面） |
+| SSE 断线/代理空闲断开 | 事件延迟 | 心跳 25s 应对代理；`retry:3000` 自动重连；`/state` 轮询兜底 + `EventSource` 内建重连 |
+| 网页端未配置 `enabled=false` 出双宠 | 两处显示同一宠物 | 网页端读取 `companionOnline` 自行隐藏（whale-girl 已具备该字段）；桌面端确保心跳存活 |
+| 状态是累积账本、无净负反馈 | 桌面端只能加互动、不能改账本 | 恪守只读 + `interact` 乐趣动作；不进任何写面（账本由 whale-girl 独占） |
+| CSS/原点 403（assets 穿越防护） | 资产加载失败 | 走 `manifest.json` 相对路径，请求净化路径；不做含 `\` 段的请求 |
+| 进程崩溃未发 `{online:false}` | 网页宠物 45s 才恢复 | 属设计内兜底：TTL 过期即自动恢复，无需手动开关 |
+
+---
+
+## 7. 验收要点
+1. 桌面进程启动后 `/state.companionOnline === true`；网页端隐藏宠物。
+2. 每 15s 心跳，窗口一直有效；进程退出（含 Ctrl+C）→ 网页宠物 45s 内恢复。
+3. 事件即时性：完成任务 → 桌面端 1 次 `/state` 往返内出 `celebrate`。
+4. 无第三方对 whale-girl 的写面污染；只做外部 HTTP 消费者。
+
+---
+
+## 附：参考契约文件（只读引用，来自 whale-girl 源码）
+- 路由端点单一来源：`lib/src/routes.mjs`
+- presence 契约：`lib/src/presence.mjs`
+- 接合：`lib/src/interact.mjs`（isCrossOrigin / applyAction）
+- 状态形状：`lib/src/pet-state.mjs`（INITIAL_STATE 字段）
+- 配置：`lib/src/config.mjs`（窗口时长、replies、walk）
+- 路由注册：`lib/index.mjs`

--- a/desktop/lib/client/behaviors.mjs
+++ b/desktop/lib/client/behaviors.mjs
@@ -1,0 +1,40 @@
+// 行为纯函数（对齐 whale-girl client/logic.mjs，无 DOM、可单测）：
+// working 随机插曲节奏、睡醒边沿、interact 醒觉决策。
+
+import {
+  WORKING_MIN_WAIT_MS, WORKING_MAX_WAIT_MS, WORKING_MIN_DUR_MS, WORKING_MAX_DUR_MS,
+} from './state.mjs'
+
+function rand(min, max) {
+  return min + Math.random() * (max - min)
+}
+
+/**
+ * working 随机插曲决策：会话思考期间偶尔插入 working 工作姿态，其余时间 think 常态。
+ * @param {object} input
+ * @param {number} input.now
+ * @param {boolean} input.sessionThink
+ * @param {object} input.working { active, until }
+ * @returns {object} { active, until }
+ */
+export function nextWorkingRhythm({ now, sessionThink, working = { active: false, until: 0 } }) {
+  if (!sessionThink) return { active: false, until: 0 }
+  if (working.active) {
+    return { active: false, until: now + rand(WORKING_MIN_DUR_MS, WORKING_MAX_DUR_MS) }
+  }
+  return { active: true, until: now + rand(WORKING_MIN_WAIT_MS, WORKING_MAX_WAIT_MS) }
+}
+
+/**
+ * 睡醒边沿：上一帧显示 sleep、本帧离开 sleep（非拖拽打断、无瞬发占用）→ 播 wake。
+ */
+export function shouldWake(prevState, nextState, ctx = {}) {
+  return prevState === 'sleep' && nextState !== 'sleep' && !ctx.dragging && (ctx.transient ?? null) === null
+}
+
+/**
+ * 互动醒觉：拖拽/喂食/玩耍都是用户在场——空闲重算；睡着则附加 wake 过渡。
+ */
+export function wakeFromInteraction({ sleeping }) {
+  return { sleeping: false, wake: sleeping === true }
+}

--- a/desktop/lib/client/companion.mjs
+++ b/desktop/lib/client/companion.mjs
@@ -68,17 +68,37 @@ export async function createCompanion(opts, hooks = {}) {
   }
 
   // —— 状态轮询 ——
+  // 并发守卫（Copilot）：refreshState 可能被 setInterval / SSE 事件 / interact 同时调用。
+  // 用 in-flight + coalesce 保证同一时刻仅一个请求在途：在途期间到达的调用打标记，
+  // 完成后若期间有新的刷新请求则再跑一次，避免并发覆盖与竞态，也不丢最新状态。
+  let refreshing = false
+  let pendingRefresh = false
   const refreshState = async () => {
-    try {
-      const body = await client.getState()
-      snapshot = body
-      await applyRemoteConfig()
-      hooks.onSnapshot?.(snapshot)
-      computeAnimation()
-      return body
-    } catch (err) {
-      log.warn('GET /state 失败:', err.message)
+    if (refreshing) {
+      pendingRefresh = true // 在途：coalesce，待本轮结束再触发一轮
       return null
+    }
+    refreshing = true
+    try {
+      do {
+        pendingRefresh = false
+        try {
+          const body = await client.getState()
+          snapshot = body
+          await applyRemoteConfig()
+          hooks.onSnapshot?.(snapshot)
+          computeAnimation()
+          if (!pendingRefresh) return body
+        } catch (err) {
+          log.warn('GET /state 失败:', err.message)
+          // 在途期间若有新的刷新请求积累，仍重试一轮
+          return null
+        }
+      } while (pendingRefresh)
+      return snapshot
+    } finally {
+      refreshing = false
+      pendingRefresh = false
     }
   }
 
@@ -134,7 +154,7 @@ export async function createCompanion(opts, hooks = {}) {
   const interact = async (action = 'feed') => {
     try {
       const body = await client.interact(action)
-      applyInteraction(sched, action) // 本地瞬发/喜悦/唤醒
+      applyInteraction(sched, action, Date.now()) // 本地瞬发/喜悦/唤醒（带注入时间源）
       const reply = body?.reply ?? null
       log.info(`互动 ${action}: ${reply ?? ''}`)
       hooks.onReply?.(reply)

--- a/desktop/lib/client/companion.mjs
+++ b/desktop/lib/client/companion.mjs
@@ -1,0 +1,172 @@
+// 桌面伴侣核心引擎：组装 heartbeat（presence 心跳）+ 状态轮询 + SSE 即时刷新 + 本地调度。
+// 与渲染解耦：只产出「当前动画意图 + 状态快照」，由外层决定如何展示
+// （headless 打日志 / Electron 画桌面）。纯 Node ESM，可被 Node 测试与 Electron main 复用。
+//
+// 对 whale-girl 的写面仅两个公开端点：
+// - POST /presence …… 显示层心跳（P0-1）
+// - POST /interact   …… 用户投喂/玩耍（P1-1）
+// 其余全部只读。账本（XP/称号）由 whale-girl 独占，本引擎绝不改写。
+
+import { createClient } from './http.mjs'
+import { createSSEClient } from './events.mjs'
+import { createLogger } from './utils.mjs'
+import { ROUTE_PREFIX } from './utils.mjs'
+import { createScheduler, stepScheduler, applyInteraction } from './scheduler.mjs'
+import { pickAnimation } from './state.mjs'
+
+/** 本地调度 tick（比 pollMs 更密：睡眠/游走/工作插曲需要细粒度推进）。 */
+const TICK_MS = 250
+
+/**
+ * 启动桌面伴侣引擎。
+ * @param {object} opts 见 src/config.mjs loadConfig()
+ * @param {object} [hooks] 渲染层 / 日志回调
+ * @param {(snapshot: object) => void} [hooks.onSnapshot] 每次 /state 轮询后的快照回调
+ * @param {(anim: {name: string, context: object}) => void} [hooks.onAnimation] 动画意图变化回调
+ * @param {(reply: string) => void} [hooks.onReply] interact 回话气泡回调
+ * @returns {{ client, stop: () => Promise<void>, interact: (action:'feed'|'play') => Promise<void>, getState: () => object }}
+ */
+export async function createCompanion(opts, hooks = {}) {
+  const log = opts.logger ?? createLogger()
+  const client = createClient({
+    baseURL: opts.baseURL,
+    routePrefix: opts.routePrefix ?? ROUTE_PREFIX,
+  })
+
+  // —— 运行时状态 ——
+  let snapshot = null            // 最近一次 /state
+  let remoteConfig = null        // /config 的 config
+  let anim = { name: 'idle', context: {} } // 最近派生动画意图
+  let stopped = false
+  const sched = createScheduler({ sleepAfterMs: opts.sleepAfterMs })
+
+  // 配置跟随：configRevision 门控（变化才重应用 /config，避免每 3s 拉一次）。
+  let lastConfigRevision = -1
+  const applyRemoteConfig = async () => {
+    if (snapshot === null || typeof snapshot.configRevision !== 'number') return
+    if (snapshot.configRevision === lastConfigRevision) return
+    lastConfigRevision = snapshot.configRevision
+    try {
+      const body = await client.getConfig()
+      remoteConfig = body?.config ?? null
+    } catch (err) {
+      log.warn('拉取 /config 失败（保持上次）:', err.message)
+    }
+  }
+
+  // 派生动画意图并回调渲染层（幂等：只通知变化）。
+  let lastAnimName = null
+  const computeAnimation = () => {
+    const next = pickAnimation(snapshot, sched)
+    anim = next
+    if (next.name !== lastAnimName) {
+      lastAnimName = next.name
+      hooks.onAnimation?.(next)
+    }
+    hooks.onTick?.(next, sched)
+    return next
+  }
+
+  // —— 状态轮询 ——
+  const refreshState = async () => {
+    try {
+      const body = await client.getState()
+      snapshot = body
+      await applyRemoteConfig()
+      hooks.onSnapshot?.(snapshot)
+      computeAnimation()
+      return body
+    } catch (err) {
+      log.warn('GET /state 失败:', err.message)
+      return null
+    }
+  }
+
+  // —— SSE 即时刷新（事件 → 立即 /state，延迟降到单次往返）——
+  let sse = null
+  const startSSE = () => {
+    if (opts.eventsEnabled === false) return
+    const url = new URL(`${opts.routePrefix ?? ROUTE_PREFIX}/events`, opts.baseURL).toString()
+    sse = createSSEClient(url, { signal: opts.signal })
+    sse.events.on('event', () => {
+      log.debug('SSE 事件 → 立即刷新 /state')
+      refreshState()
+    })
+    sse.events.on('reconnect', () => log.debug('SSE 重连'))
+    sse.events.on('error', (err) => log.warn('SSE:', err.message))
+  }
+
+  // —— presence 心跳（15s；退出时 {online:false} 清理）——
+  // AbortSignal 超时：退出/下线时不因 DSH web 瞬时不可达而挂死（reviewer 建议）。
+  const PRESENCE_TIMEOUT_MS = 2000
+  const sendPresence = async (online) => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), PRESENCE_TIMEOUT_MS)
+    try {
+      const body = await client.setPresence(online, { signal: controller.signal })
+      return body
+    } catch (err) {
+      log.warn(`POST /presence ${online ? '上线' : '下线'} 失败:`, err.message)
+      return null
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+  let heartbeatTimer = null
+  const startHeartbeat = () => {
+    if (opts.autoPresence === false) return
+    heartbeatTimer = setInterval(() => sendPresence(true), opts.heartbeatMs)
+  }
+
+  // 启动
+  if (opts.autoPresence !== false) await sendPresence(true) // 立即宣告在场（网页端据此隐藏宠物）
+  startHeartbeat()
+  await refreshState()
+  startSSE()
+  const pollTimer = setInterval(refreshState, opts.pollMs)
+  const tickTimer = setInterval(() => {
+    if (stopped) return
+    stepScheduler(sched, { snapshot, now: Date.now() })
+    computeAnimation()
+  }, TICK_MS)
+
+  // —— 互动（P1-1）——
+  const interact = async (action = 'feed') => {
+    try {
+      const body = await client.interact(action)
+      applyInteraction(sched, action) // 本地瞬发/喜悦/唤醒
+      const reply = body?.reply ?? null
+      log.info(`互动 ${action}: ${reply ?? ''}`)
+      hooks.onReply?.(reply)
+      await refreshState()
+      computeAnimation()
+      return body
+    } catch (err) {
+      log.warn(`POST /interact ${action} 失败:`, err.message)
+      return null
+    }
+  }
+
+  // —— 停止清理 ——
+  const stop = async () => {
+    if (stopped) return
+    stopped = true
+    clearInterval(heartbeatTimer)
+    clearInterval(pollTimer)
+    clearInterval(tickTimer)
+    if (sse) sse.close()
+    if (opts.cleanupOnExit !== false) {
+      await sendPresence(false) // 显式下线，网页宠物立即恢复
+    }
+    log.info('伴侣已停止（presence 已下线）')
+  }
+
+  return {
+    client,
+    interact,
+    getState: () => snapshot,
+    getAnimation: () => anim,
+    get scheduler() { return sched },
+    stop,
+  }
+}

--- a/desktop/lib/client/events.mjs
+++ b/desktop/lib/client/events.mjs
@@ -15,6 +15,18 @@ const DEFAULT_RETRY_MS = 3000
 const HEARTBEAT_GUARD_MS = 90000
 
 /**
+ * 找下一个 SSE 事件块分隔点（空行）。SSE 规范允许 LF("\n\n") 或 CRLF("\r\n\r\n")——
+ * 返回分隔符之前的 index（即块内容结束处）；无分隔返回 -1。
+ */
+function findBlockBoundary(buffer) {
+  const lf = buffer.indexOf('\n\n')
+  const crlf = buffer.indexOf('\r\n\r\n')
+  if (lf === -1) return crlf
+  if (crlf === -1) return lf
+  return Math.min(lf, crlf)
+}
+
+/**
  * SSE 订阅器（EventEmitter，事件：event / reconnect / error / open）。
  * @param {string} url 事件流 URL
  * @param {object} [opts]
@@ -54,11 +66,13 @@ export function createSSEClient(url, { retryMs = DEFAULT_RETRY_MS, signal } = {}
         const { done, value } = await reader.read()
         if (done) break
         buffer += decoder.decode(value, { stream: true })
-        // 以空行分隔事件块
+        // 以空行分隔事件块。SSE 规范允许 LF(\n) 与 CRLF(\r\n)：同时匹配两种，
+        // 取最早出现的分隔点，避免仅识别 "\n\n" 时 CRLF 服务的缓冲永不切块。
         let sep
-        while ((sep = buffer.indexOf('\n\n')) !== -1) {
-          const raw = buffer.slice(0, sep + 2)
-          buffer = buffer.slice(sep + 2)
+        while ((sep = findBlockBoundary(buffer)) !== -1) {
+          const raw = buffer.slice(0, sep)
+          // 跳过分隔符自身的换行（\n\n 或 \r\n\r\n）
+          buffer = buffer.slice(sep + (buffer[sep] === '\r' ? 4 : 2))
           handleChunk(raw)
         }
       }
@@ -94,9 +108,16 @@ export function createSSEClient(url, { retryMs = DEFAULT_RETRY_MS, signal } = {}
   let reconnectTimer = null
   function scheduleReconnect() {
     if (closed) return
-    reconnectTimer = setTimeout(async () => {
+    // 先清掉未触发的旧 timer，避免并发调度重复重连（Copilot: timer 覆盖泄漏）。
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      if (closed) return
       em.emit('reconnect')
-      await streamOnce()
+      streamOnce()
     }, retry)
   }
 
@@ -111,7 +132,10 @@ export function createSSEClient(url, { retryMs = DEFAULT_RETRY_MS, signal } = {}
   function close() {
     closed = true
     clearInterval(guard)
-    clearingTimeout(reconnectTimer)
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
     controller?.abort()
     em.emit('close')
   }
@@ -120,8 +144,4 @@ export function createSSEClient(url, { retryMs = DEFAULT_RETRY_MS, signal } = {}
   streamOnce()
 
   return { events: em, close }
-}
-
-function clearingTimeout(t) {
-  if (t) clearTimeout(t)
 }

--- a/desktop/lib/client/events.mjs
+++ b/desktop/lib/client/events.mjs
@@ -1,0 +1,127 @@
+// SSE（Server-Sent Events）客户端：订阅 whale-girl /events 事件流。
+// 用 fetch 流式读取（Node ≥18 原生 fetch，无需全局 EventSource）。
+// 行为对齐 DESIGN.md §3.2：收到 data 事件 → 回调触发一次 /state 刷新；
+// 断线自动按 retry 重连；25s 心跳 `: ping` 注释行忽略。
+//
+// 事件语义：whale-girl 推送 `data: {"type":"event"}\n\n` 表示"状态已变化，
+// 请重新拉 /state"。本模块不自解释具体字段，只负责把连接生命周期与"收到事件"
+// 转成事件回调（onEvent / onReconnect / onError）。
+
+import { EventEmitter } from 'node:events'
+
+/** 默认重连间隔（whale-girl SSE 发 `retry: 3000`，兜底 3s）。 */
+const DEFAULT_RETRY_MS = 3000
+/** 单次连接最大存活（交由 heartbeat 续命；SSE 路由心跳 25s，这里留余量防僵连）。 */
+const HEARTBEAT_GUARD_MS = 90000
+
+/**
+ * SSE 订阅器（EventEmitter，事件：event / reconnect / error / open）。
+ * @param {string} url 事件流 URL
+ * @param {object} [opts]
+ * @param {number|string} [opts.retryMs] 初始重连间隔（可被服务器 retry 覆盖）
+ * @param {AbortSignal} [opts.signal] 退出信号
+ */
+export function createSSEClient(url, { retryMs = DEFAULT_RETRY_MS, signal } = {}) {
+  const em = new EventEmitter()
+  let controller = null
+  let closed = false
+  let retry = Number(retryMs) || DEFAULT_RETRY_MS
+  let lastPingAt = 0
+
+  async function streamOnce() {
+    if (closed) return
+    // each: 用 AbortController 控制每次连接，重连时重建。
+    controller = new AbortController()
+    const abort = () => controller.abort()
+    if (signal) {
+      if (signal.aborted) { close(); return }
+      signal.addEventListener('abort', abort, { once: true })
+    }
+    try {
+      const res = await fetch(url, {
+        headers: { accept: 'text/event-stream' },
+        signal: controller.signal,
+      })
+      if (!res.ok || !res.body) {
+        throw new Error(`SSE connect HTTP ${res.status}`)
+      }
+      em.emit('open')
+      lastPingAt = Date.now()
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      while (!closed && !controller.signal.aborted) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        // 以空行分隔事件块
+        let sep
+        while ((sep = buffer.indexOf('\n\n')) !== -1) {
+          const raw = buffer.slice(0, sep + 2)
+          buffer = buffer.slice(sep + 2)
+          handleChunk(raw)
+        }
+      }
+    } catch (err) {
+      if (closed || controller.signal.aborted) return
+      em.emit('error', err)
+    } finally {
+      if (signal) signal.removeEventListener('abort', abort)
+      if (!closed) scheduleReconnect()
+    }
+  }
+
+  function handleChunk(raw) {
+    // 逐行解析 SSE 字段（data: / retry: / 注释行）
+    const dataLines = []
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).trim())
+      } else if (line.startsWith(':')) {
+        // 注释行（含心跳给 ping）——忽略
+      } else if (line.startsWith('retry:')) {
+        const v = Number(line.slice(6).trim())
+        if (Number.isFinite(v) && v > 0) retry = v
+      }
+    }
+    lastPingAt = Date.now()
+    if (dataLines.length) {
+      const payload = dataLines.join('\n')
+      em.emit('event', payload)
+    }
+  }
+
+  let reconnectTimer = null
+  function scheduleReconnect() {
+    if (closed) return
+    reconnectTimer = setTimeout(async () => {
+      em.emit('reconnect')
+      await streamOnce()
+    }, retry)
+  }
+
+  // 心跳守卫：超过 HEARTBEAT_GUARD_MS 无任何数据（服务器僵连）→ 主动断开重连。
+  const guard = setInterval(() => {
+    if (closed) return
+    if (Date.now() - lastPingAt > HEARTBEAT_GUARD_MS) {
+      controller?.abort()
+    }
+  }, Math.min(30000, HEARTBEAT_GUARD_MS))
+
+  function close() {
+    closed = true
+    clearInterval(guard)
+    clearingTimeout(reconnectTimer)
+    controller?.abort()
+    em.emit('close')
+  }
+
+  // 启动
+  streamOnce()
+
+  return { events: em, close }
+}
+
+function clearingTimeout(t) {
+  if (t) clearTimeout(t)
+}

--- a/desktop/lib/client/http.mjs
+++ b/desktop/lib/client/http.mjs
@@ -1,0 +1,64 @@
+// HTTP 消费者封装：对 whale-girl 端点的只读 + 写面（interact/presence）。
+// 全部原生 fetch（Node ≥18 全局），零第三方依赖。
+// 契约对齐：见 DESIGN.md §3；isCrossOrigin 若本地调用缺 Origin/Sec-Fetch-Site 视为同源（已验证）。
+//
+// 错误语义：网络/HTTP 异常抛出带 status 的错误；调用方据此区分瞬态/终态。
+
+import { ROUTE } from './utils.mjs'
+
+/**
+ * 创建绑定到指定 BaseURL 的 whale-girl HTTP 客户端。
+ * @param {{ baseURL: string, routePrefix?: string, pollMs?: number }} opts
+ */
+export function createClient({ baseURL, routePrefix = '/whale-girl' }) {
+  const url = (path) => new URL(`${routePrefix}${path}`, baseURL).toString()
+
+  async function request(method, path, body, { signal } = {}) {
+    const res = await fetch(url(path), {
+      method,
+      headers: body !== undefined
+        ? { 'content-type': 'application/json' }
+        : { accept: 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal,
+    })
+    if (!res.ok) {
+      const err = new Error(`whale-girl ${method} ${path} → HTTP ${res.status}`)
+      err.status = res.status
+      throw err
+    }
+    return res.json()
+  }
+
+  return {
+    baseURL,
+    url,
+
+    /** GET /state → { apiVersion, pet, activity, configRevision, companionOnline } */
+    getState: () => request('GET', '/state'),
+
+    /** GET /config → { config, revision } */
+    getConfig: () => request('GET', '/config'),
+
+    /** GET /sessions → Array<{ id, title, activity, since }> */
+    getSessions: () => request('GET', '/sessions'),
+
+    /** GET /assets/manifest.json → 角色/状态/帧配置 */
+    getManifest: () => request('GET', '/assets/manifest.json'),
+
+    /**
+     * POST /presence → { online: boolean }
+     * @param {boolean} online true=上线续命，false=立即下线
+     * @param {{signal?: AbortSignal}} [opts] 可选 AbortSignal（退出清理超时用）
+     */
+    setPresence: (online = true, opts = {}) => request('POST', '/presence', { online }, opts),
+
+    /**
+     * POST /interact → { pet, reply }
+     * @param {'feed'|'play'} action 投喂/玩耍（纯乐趣，零账本写面）
+     */
+    interact: (action = 'feed') => request('POST', '/interact', { action }),
+  }
+}
+
+export { ROUTE }

--- a/desktop/lib/client/scheduler.mjs
+++ b/desktop/lib/client/scheduler.mjs
@@ -88,13 +88,15 @@ export function stepScheduler(sched, { snapshot, now = Date.now() } = {}) {
 }
 
 /** interact 后重置空闲 + eat/play 瞬发（对齐 whale-girl：互动瞬发优先于醒觉——
- *  喂食/玩耍直接播 eat/play；wake 只用于拖拽放下等非互动路径，桌面端无拖拽故不产生）。 */
-export function applyInteraction(sched, action) {
+ *  喂食/玩耍直接播 eat/play；wake 只用于拖拽放下等非互动路径，桌面端无拖拽故不产生）。
+ *  `now` 显式注入（默认 Date.now()），与 stepScheduler 的可测时间源保持一致
+ *  （Copilot：允许测试注入确定性时间，而非直接调用 Date.now()）。 */
+export function applyInteraction(sched, action, now = Date.now()) {
   const decision = wakeFromInteraction({ sleeping: sched.sleeping })
   sched.sleeping = decision.sleeping
   sched.idleSince = 0
-  sched.joyUntil = Date.now() + JOY_MS
+  sched.joyUntil = now + JOY_MS
   sched.transient = action === 'feed' ? 'eat' : 'play'
-  sched.transientUntil = Date.now() + TRANSIENT_MS
+  sched.transientUntil = now + TRANSIENT_MS
   return sched
 }

--- a/desktop/lib/client/scheduler.mjs
+++ b/desktop/lib/client/scheduler.mjs
@@ -1,0 +1,100 @@
+// 本地行为调度器：驱动桌面端在 /state 之外的本地节奏——睡眠（sleep）、
+// 游走（walk 动画意图）、working 随机插曲、interact 瞬发（eat/play/joy/wake）。
+//
+// 与 whale-girl runtime 解耦：/state 只给「事实窗口」（activity burst、sessionThink、
+// sessionWait、turnCompletedUntil），本地调度补「节奏」（睡/醒、走、工作插曲、互动瞬发）。
+// 所有字段是纯数据（可序列化），由引擎每个 tick 调用 step() 推进。
+//
+// 默认节奏参数与 whale-girl client 对齐（见 DESIGN.md §3）。
+
+import {
+  JOY_MS, TRANSIENT_MS, SLEEP_AFTER_MS,
+  WORKING_MIN_WAIT_MS, WORKING_MAX_WAIT_MS, WORKING_MIN_DUR_MS, WORKING_MAX_DUR_MS,
+} from './state.mjs'
+import { nextWorkingRhythm, shouldWake, wakeFromInteraction } from './behaviors.mjs'
+
+function rand(min, max) {
+  return min + Math.random() * (max - min)
+}
+
+/** 初始调度状态。 */
+export function createScheduler({ sleepAfterMs = SLEEP_AFTER_MS } = {}) {
+  return {
+    sleepAfterMs,
+    idleSince: 0,          // 进入 idle 的时刻（睡眠由此起算）
+    sleeping: false,       // 当前是否打盹
+    joyUntil: 0,           // interact 后喜悦窗口
+    transient: null,       // 'eat'|'play'|'wake'|null
+    transientUntil: 0,
+    walking: false,
+    nextWalkAt: 0,
+    working: { active: false, until: 0 },
+    lastActivityState: 'idle',
+  }
+}
+
+/**
+ * 每 tick 推进调度（调用引擎的轮询刷新）。
+ * @param {object} sched 调度状态
+ * @param {object} ctx
+ * @param {object} ctx.snapshot /state 快照（activity 等）
+ * @param {number} ctx.now
+ */
+export function stepScheduler(sched, { snapshot, now = Date.now() } = {}) {
+  const act = snapshot?.activity ?? { name: 'idle', until: 0 }
+  // 瞬发复位（eat/play/wake 播完或超时）
+  if (sched.transient !== null && now >= sched.transientUntil) {
+    const wasFun = sched.transient === 'eat' || sched.transient === 'play'
+    sched.transient = null
+    if (wasFun) sched.joyUntil = now + JOY_MS
+  }
+  // 会话活跃性 → 空闲起算 / 睡眠
+  const isActive = act.name !== 'idle' || act.until > now
+  if (isActive) {
+    sched.idleSince = 0
+  } else if (sched.idleSince === 0) {
+    sched.idleSince = now
+  }
+  sched.sleeping = act.name === 'idle' && sched.idleSince !== 0 && now - sched.idleSince > sched.sleepAfterMs
+
+  // working 随机插曲（仅会话思考期间武装；到点才重新决策——nextWorkingRhythm 返回
+  // 的 until 是「新阶段结束时刻」，不能每 tick 无条件翻转，否则 think/working 高频抖动）
+  if (act.sessionThink !== true) {
+    if (sched.working.active !== false || sched.working.until !== 0) {
+      sched.working = { active: false, until: 0 }
+    }
+  } else if (sched.working.until === 0 || now >= sched.working.until) {
+    sched.working = nextWorkingRhythm({ now, sessionThink: true, working: sched.working })
+  }
+
+  // 游走节奏（简单周期：空闲时偶尔走一段；离开空闲即重置排程，避免回空闲时立刻走）
+  if (sched.walking) {
+    if (now >= sched.nextWalkAt) {
+      sched.walking = false
+      sched.nextWalkAt = now + rand(18000, 40000)
+    }
+  } else if (!sched.sleeping && act.name === 'idle') {
+    if (sched.nextWalkAt === 0) sched.nextWalkAt = now + rand(18000, 40000)
+    if (now >= sched.nextWalkAt) {
+      sched.walking = true
+      sched.nextWalkAt = now + rand(3000, 6000)
+    }
+  } else {
+    if (sched.walking) sched.walking = false
+    sched.nextWalkAt = 0 // 非空闲：游走排程复位
+  }
+
+  return sched
+}
+
+/** interact 后重置空闲 + eat/play 瞬发（对齐 whale-girl：互动瞬发优先于醒觉——
+ *  喂食/玩耍直接播 eat/play；wake 只用于拖拽放下等非互动路径，桌面端无拖拽故不产生）。 */
+export function applyInteraction(sched, action) {
+  const decision = wakeFromInteraction({ sleeping: sched.sleeping })
+  sched.sleeping = decision.sleeping
+  sched.idleSince = 0
+  sched.joyUntil = Date.now() + JOY_MS
+  sched.transient = action === 'feed' ? 'eat' : 'play'
+  sched.transientUntil = Date.now() + TRANSIENT_MS
+  return sched
+}

--- a/desktop/lib/client/state-names.mjs
+++ b/desktop/lib/client/state-names.mjs
@@ -1,0 +1,10 @@
+// 动画状态名权威集合（与 whale-girl lib/client/logic.mjs 的 STATE_NAMES 对齐）。
+// 渲染层/状态机用它校验 animationState 是否合法；未知状态回退占位/idle。
+export const STATE_NAMES = Object.freeze([
+  'idle', 'working', 'celebrate', 'error', 'disappointed', 'joy', 'eat', 'play',
+  'drag', 'walk', 'sleep', 'wake', 'welcome', 'think', 'wait',
+])
+
+export function isKnownState(name) {
+  return STATE_NAMES.includes(name)
+}

--- a/desktop/lib/client/state.mjs
+++ b/desktop/lib/client/state.mjs
@@ -1,0 +1,89 @@
+// 状态机：把 whale-girl /state 的 activity + pet 快照映射为「动画意图」。
+// 与 whale-girl client/logic.mjs 的 pickState 对齐（同一状态集合/优先级），
+// 但纯 Node、无 DOM、去掉 drag（桌面端不走拖拽）：
+// 优先级 = activity burst > transient(本地) > wait > celebrate(回合完成) > working(随机插曲) > think > joy > sleep > walk > idle。
+//
+// 输出 { name, context }：
+// - name：动画状态名（15 状态之一，见 whale-girl manifest）
+// - context：渲染层需要的最小参数（如 opSize 工具窗尺寸）
+//
+// 状态：本模块是无状态纯函数 + 一个可持久的调度器（working 随机插曲 / 睡眠 / 游走）。
+
+import { STATE_NAMES } from './state-names.mjs'
+
+// 与 whale-girl tick 配合的本地参数（对齐 client/logic.mjs 常量）
+export const WAKE_MS = 3000        // 睡醒过渡
+export const JOY_MS = 1600         // interact 后短时喜悦
+export const TRANSIENT_MS = 1500   // eat/play 瞬发
+export const SLEEP_AFTER_MS = 60000 // 空闲 ≥60s 打盹（与 whale-girl 默认一致）
+// working 随机插曲（会话思考期间偶尔插入，见 whale-girl logic）
+export const WORKING_MIN_WAIT_MS = 12000
+export const WORKING_MAX_WAIT_MS = 30000
+export const WORKING_MIN_DUR_MS = 2500
+export const WORKING_MAX_DUR_MS = 6000
+
+/**
+ * 状态优先级表（行序即优先级；与 whale-girl 对齐，去掉 drag）。
+ * input：{ activity, sessionThink, sessionWait, turnCompleted, celebrateUntil, joyUntil,
+ *          sleep, walking, transient, workingActive }
+ */
+export const STATE_TABLE = [
+  // activity 事件 burst（welcome/celebrate/error/disappointed/joy）：until 有效期内优先。
+  // 注意用 c.now（注入的可测时间），不是 Date.now()——pickState 是纯函数，测试传固定 now。
+  { state: 'burst', when: (c) => c.activity.name !== 'idle' && c.activity.name !== 'working' && c.activity.until > c.now, resolve: (c) => c.activity.name },
+  { state: 'eat', when: (c) => c.transient === 'eat' },
+  { state: 'play', when: (c) => c.transient === 'play' },
+  { state: 'wake', when: (c) => c.transient === 'wake' },
+  { state: 'wait', when: (c) => c.sessionWait },
+  // 回合完成庆祝（client 本地窗口，低于事件 burst）
+  { state: 'celebrate', when: (c) => c.celebrateUntil > c.now },
+  { state: 'working', when: (c) => c.workingActive },
+  { state: 'think', when: (c) => c.sessionThink },
+  { state: 'joy', when: (c) => c.now < c.joyUntil },
+  { state: 'sleep', when: (c) => c.sleep },
+  { state: 'walk', when: (c) => c.walking },
+  { state: 'idle', when: () => true },
+]
+
+/** 选择动画状态名（now 显式，测试确定性）。 */
+export function pickState(input) {
+  const ctx = { now: input.now ?? Date.now(), ...input }
+  for (const row of STATE_TABLE) {
+    if (row.when(ctx)) return row.resolve ? row.resolve(ctx) : row.state
+  }
+  return 'idle'
+}
+
+/**
+ * 结合 /state 快照与本地调度器派生动画意图。
+ * @param {object} body /state 响应
+ * @param {object} sched 本地调度状态（见 scheduler.mjs createScheduler）
+ * @returns {{ name: string, context: object }}
+ */
+export function pickAnimation(body, sched = {}) {
+  const act = body?.activity ?? { name: 'idle', until: 0 }
+  const now = Date.now()
+  const name = pickState({
+    activity: act,
+    sessionThink: act.sessionThink === true,
+    sessionWait: act.sessionWait === true,
+    celebrateUntil: act.turnCompletedUntil ?? 0,
+    joyUntil: sched.joyUntil ?? 0,
+    transient: sched.transient ?? null,
+    sleep: sched.sleeping === true,
+    walking: sched.walking === true,
+    workingActive: sched.working?.active === true,
+    now,
+  })
+  return {
+    name,
+    context: {
+      activityName: act.name,
+      pet: body?.pet ?? null,
+      sessionThink: act.sessionThink === true,
+      sessionWait: act.sessionWait === true,
+      size: body?.size ?? null,
+      until: act.until ?? 0,
+    },
+  }
+}

--- a/desktop/lib/client/utils.mjs
+++ b/desktop/lib/client/utils.mjs
@@ -1,0 +1,25 @@
+// whale-girl-desktop 共用小工具：路由拼接与轻量日志。
+// 路由前缀单一来源：默认与 whale-girl lib/src/routes.mjs 的 ROUTE_PREFIX 一致（/whale-girl），
+// 不手写漂移。
+
+export const ROUTE_PREFIX = '/whale-girl'
+
+/** @returns `{prefix}${path}`，路径以 / 开头 */
+export function ROUTE(path) {
+  return `${ROUTE_PREFIX}${path}`
+}
+
+/** 简易分级日志（避免无关噪音；可用 --quiet 关闭）。 */
+export function createLogger({ quiet = false, tag = 'whale-girl-desktop' } = {}) {
+  const ts = () => new Date().toLocaleTimeString('zh-CN', { hour12: false })
+  const write = (level, ...args) => {
+    if (quiet && level === 'debug') return
+    console.log(`[${ts()}] [${tag}] [${level}]`, ...args)
+  }
+  return {
+    info: (...a) => write('info', ...a),
+    debug: (...a) => write('debug', ...a),
+    warn: (...a) => write('warn', ...a),
+    error: (...a) => write('error', ...a),
+  }
+}

--- a/desktop/lib/index.mjs
+++ b/desktop/lib/index.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// whale-girl-desktop 入口。
+// - 纯 Node 运行（node lib/index.mjs）：headless 模式（心跳 + 状态 + SSE + 日志），
+//   或 --headless 显式指定。用于自测/CI/无桌面环境。
+// - Electron 运行（electron . / electron lib/index.mjs）：创建透明置顶桌面窗渲染宠物，
+//   核心引擎（companion）在 Electron main 进程内运行，经 IPC 把动画意图推给 renderer。
+
+import { loadConfig } from './src/config.mjs'
+import { createLogger } from './client/utils.mjs'
+
+// 解析 CLI（在 import 副作用前做，避免被测试覆盖）
+const cfg = loadConfig()
+const log = createLogger({ tag: 'whale-girl-desktop' })
+
+const isElectronMain = typeof process !== 'undefined' && process.versions?.electron !== undefined
+const headless = !cfg.renderEnabled || process.argv.includes('--headless')
+
+if (isElectronMain && !headless) {
+  // —— Electron main 路径：桌面渲染 ——
+  // 注意：不要顶层 await runDesktop()——runDesktop 内部 await app.whenReady()，
+  // 若在入口模块顶层 await，会阻塞 Electron 事件循环导致 ready 永不触发（ESM main 陷阱）。
+  // 改为 fire-and-forget：runDesktop 自带 async 生命周期，错误会先记录再退出。
+  const { runDesktop } = await import('./render/window.mjs')
+  process.nextTick(() => {
+    runDesktop({ cfg, log }).catch((err) => {
+      try { log.error('桌面渲染启动失败:', err?.message ?? err) } catch {}
+      process.exit(1)
+    })
+  })
+} else {
+  // —— headless 路径：只跑核心（心跳 + 状态 + SSE），供自测与无桌面环境 ——
+  const { createCompanion } = await import('./client/companion.mjs')
+  const companion = await createCompanion(cfg, {
+    onSnapshot: (snap) => {
+      const act = snap?.activity?.name ?? '?'
+      const lv = snap?.pet?.level ?? '?'
+      const online = snap?.companionOnline === true
+      log.info(`state: activity=${act} Lv.${lv} companionOnline=${online}`)
+    },
+    onAnimation: (anim) => log.debug(`anim → ${anim.name}`),
+    onReply: (reply) => log.info(`reply: ${reply}`),
+  })
+  log.info(`headless 模式运行中：BaseURL=${cfg.baseURL} pollMs=${cfg.pollMs} heartbeatMs=${cfg.heartbeatMs}`)
+  log.info('按 Ctrl+C 退出（退出时自动发送 {online:false}）')
+
+  const shutdown = () => {
+    companion.stop().then(() => process.exit(0))
+  }
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}

--- a/desktop/lib/render/window.mjs
+++ b/desktop/lib/render/window.mjs
@@ -43,7 +43,9 @@ function createWindow() {
       preload: join(RENDER_DIR, 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false, // preload 用 ESM 风格 require-free；保持最小
+      // sandbox:true —— preload 只用 contextBridge/ipcRenderer（sandboxed preload 原生可用）；
+      // renderer 无 Node 全局、只暴露 whaleGirl.*，安全边界最大化（Copilot 建议）。
+      sandbox: true,
     },
   })
   win.setAlwaysOnTop(true, 'screen-saver')

--- a/desktop/lib/render/window.mjs
+++ b/desktop/lib/render/window.mjs
@@ -1,0 +1,150 @@
+// Electron 桌面渲染壳（main 进程）：
+// - 透明、无边框、置顶的宠物窗口
+// - 核心引擎（createCompanion）在本进程运行，hooks 把动画意图/快照/回话经 IPC 推给 renderer
+// - 渲染层零网络：manifest/sprite 由本进程拉取转 dataURL 再下发（绕过 CORS、单一数据通道）
+// - 退出时显式 {online:false}（companion.stop()），网页宠物即恢复
+//
+// 由于鲸鱼娘 sprite 站姿是「透明图 + 四周透明」，窗口需要精确贴合内容才不挡鼠标——
+// renderer 侧用 canvas 内容 bbox 计算实际不透明区，据此切换 ignoreMouseEvents（点击穿透）。
+
+import { app, BrowserWindow, ipcMain } from 'electron'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createClient } from '../client/http.mjs'
+import { createCompanion } from '../client/companion.mjs'
+import { createLogger } from '../client/utils.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RENDER_DIR = join(__dirname, '..', '..', 'render')
+
+const DEFAULT_SIZE = 110
+
+let win = null
+let companion = null
+
+/**
+ * 创建透明置顶宠物窗口。
+ */
+function createWindow() {
+  win = new BrowserWindow({
+    width: DEFAULT_SIZE + 40,   // 稍大留呼吸边（视觉 shadow 余量）
+    height: DEFAULT_SIZE + 40,
+    transparent: true,
+    frame: false,
+    alwaysOnTop: true,
+    resizable: false,
+    hasShadow: false,
+    skipTaskbar: true,
+    fullscreenable: false,
+    maximizable: false,
+    minimizable: false,
+    // 只加载本地 render/ 页面（file://）+ 本机 IPC；不开 remote。
+    webPreferences: {
+      preload: join(RENDER_DIR, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false, // preload 用 ESM 风格 require-free；保持最小
+    },
+  })
+  win.setAlwaysOnTop(true, 'screen-saver')
+  win.loadFile(join(RENDER_DIR, 'index.html'))
+
+  // 默认点击穿透（只有宠物本体可交互）——renderer 每帧回调真实 bbox。
+  win.setIgnoreMouseEvents(true, { forward: true })
+
+  win.on('closed', () => { win = null })
+  return win
+}
+
+/**
+ * 主进程骨架：加载 manifest/sprite，喂给 renderer。
+ */
+function setupIpc(client) {
+  const sheetCache = new Map() // `${characterId}/${sheet}` → dataURL
+
+  ipcMain.handle('wg:manifest', async () => {
+    try {
+      return await client.getManifest()
+    } catch (err) {
+      return { error: err.message }
+    }
+  })
+
+  ipcMain.handle('wg:sheet', async (_e, { characterId = 'whale-girl', sheet }) => {
+    const key = `${characterId}/${sheet}`
+    if (sheetCache.has(key)) return sheetCache.get(key)
+    const url = `${client.url(`/assets/characters/${characterId}/${sheet}`)}`
+    try {
+      const res = await fetch(url)
+      if (!res.ok) return null
+      const buf = Buffer.from(await res.arrayBuffer())
+      const { nativeImage } = await import('electron')
+      const img = nativeImage.createFromBuffer(buf)
+      const dataURL = img.toDataURL()
+      sheetCache.set(key, dataURL)
+      return dataURL
+    } catch (err) {
+      console.error(`[wg:sheet] ${key} 失败:`, err.message)
+      return null
+    }
+  })
+
+  ipcMain.on('wg:interact', async (_e, action) => {
+    if (companion) await companion.interact(action === 'play' ? 'play' : 'feed')
+  })
+
+  // 渲染层告知宠物内容 bbox → 切换点击穿透（桌面宠物不挡非宠物区域）：
+  // 有内容（宠物可见）→ 窗口可交互（点击投喂/拖拽）；null（占位/空）→ 全透。
+  // P2 增强：可进一步把窗口缩到内容 bbox 精确贴合（见 DESIGN §6 风险对策）。
+  ipcMain.on('wg:set-hitarea', (_e, rect) => {
+    if (!win) return
+    win.setIgnoreMouseEvents(rect === null, { forward: true })
+  })
+
+  // 渲染层拖拽移动窗口：告知屏幕 delta（让宠物可拖动换位）
+  ipcMain.on('wg:drag-window', (_e, { dx, dy }) => {
+    if (!win) return
+    const [x, y] = win.getPosition()
+    win.setPosition(x + Math.round(dx), y + Math.round(dy))
+  })
+}
+
+/**
+ * 启动桌面渲染（Electron main 路径入口）。
+ */
+export async function runDesktop({ cfg, log }) {
+  const client = createClient({ baseURL: cfg.baseURL })
+
+  await app.whenReady()
+  log.info('Electron 就绪，创建宠物窗口')
+  createWindow()
+  setupIpc(client)
+
+  companion = await createCompanion(cfg, {
+    onSnapshot: (snap) => {
+      if (win) win.webContents.send('wg:snapshot', snap)
+    },
+    onAnimation: (anim) => {
+      if (win) win.webContents.send('wg:anim', anim)
+    },
+    onReply: (reply) => {
+      if (win) win.webContents.send('wg:reply', reply)
+    },
+  })
+
+  log.info(`桌面渲染运行中：BaseURL=${cfg.baseURL}（在场上线）`)
+
+  const shutdown = async () => {
+    if (companion) await companion.stop()
+    app.quit()
+  }
+  app.on('before-quit', (e) => {
+    // 幂等：before-quit 可多次触发
+  })
+  app.on('window-all-closed', () => {
+    // 宠物窗口关闭 = 退出（不留后台）
+    shutdown()
+  })
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}

--- a/desktop/lib/src/config.mjs
+++ b/desktop/lib/src/config.mjs
@@ -1,0 +1,63 @@
+// whale-girl-desktop 本地配置：桌面端运行参数（与 whale-girl /whale-girl/config 的
+// 体验层配置分开——这里管「桌面端如何连接与跑」，不是 whale-girl 的宠物配置）。
+//
+// 契约红线：
+// - BaseURL 指向 DSH web 服务（默认 http://127.0.0.1:3080）。
+// - pollMs / heartbeatMs / presenceTTLMs 需与 whale-girl /presence 契约匹配：
+//   心跳窗口 45s，每 15s 续命一次（heartbeatMs < presenceTTLMs，留足余量）。
+// - 运行时参数可由 CLI / 环境变量覆盖（见 loadConfig）。
+
+export const DEFAULTS = Object.freeze({
+  // DSH web 服务根
+  baseURL: 'http://127.0.0.1:3080',
+  // 路由前缀（与 whale-girl lib/src/routes.mjs 单一来源一致，勿手写漂移）
+  routePrefix: '/whale-girl',
+  // 状态轮询间隔（whale-girl 默认 pollMs=3000）
+  pollMs: 3000,
+  // presence 心跳间隔（whale-girl PRESENCE_TTL_MS=45s；15s 续命 < 45s 余量充分）
+  heartbeatMs: 15000,
+  // SSE 事件流：收到事件即触发一次 /state 刷新
+  eventsEnabled: true,
+  // 启动时是否自动宣告在线（--headless 也心跳，让网页端隐藏宠物）
+  autoPresence: true,
+  // 退出时是否显式下线（{online:false}）
+  cleanupOnExit: true,
+  // 渲染层开关：false 时只跑核心（心跳+状态+SSE，不弹桌面窗）
+  renderEnabled: true,
+  // 宠物默认尺寸（px；跟随 /config.size 热更新）
+  size: 110,
+  // 文字角标/气泡开关
+  showStatus: true,
+})
+
+/**
+ * 解析合并后的运行配置：环境变量 DSH_* 与 CLI 覆盖缺省。
+ * @param {{env?: Record<string,string|undefined>, argv?: string[]}} [ctx]
+ * @returns {object}
+ */
+export function loadConfig({ env = process.env ?? {}, argv = process.argv ?? [] } = {}) {
+  const cfg = { ...DEFAULTS }
+
+  if (env.WHALE_GIRL_BASE_URL) cfg.baseURL = env.WHALE_GIRL_BASE_URL.replace(/\/+$/, '')
+  if (env.WHALE_GIRL_POLL_MS != null) cfg.pollMs = Number(env.WHALE_GIRL_POLL_MS) || cfg.pollMs
+  if (env.WHALE_GIRL_HEARTBEAT_MS != null) cfg.heartbeatMs = Number(env.WHALE_GIRL_HEARTBEAT_MS) || cfg.heartbeatMs
+
+  // CLI: --headless / --base-url=<url> / --poll-ms=<n> / --no-presence / --no-render
+  if (argv.includes('--headless')) cfg.renderEnabled = false
+  if (argv.includes('--no-render')) cfg.renderEnabled = false
+  if (argv.includes('--no-presence')) cfg.autoPresence = false
+  for (const arg of argv) {
+    const m = /^--base-url=(.+)$/.exec(arg)
+    if (m) cfg.baseURL = m[1].replace(/\/+$/, '')
+    const p = /^--poll-ms=(\d+)$/.exec(arg)
+    if (p) cfg.pollMs = Number(p[1])
+    const h = /^--heartbeat-ms=(\d+)$/.exec(arg)
+    if (h) cfg.heartbeatMs = Number(h[1])
+  }
+  return cfg
+}
+
+/** whale-girl /config 返回的体验层配置（消费端只读；走 configRevision 门控）。 */
+export const REMOTE_DEFAULTS = Object.freeze({
+  enabled: true, size: 110, opacity: 1, pollMs: 3000,
+})

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "whale-girl-desktop",
+  "version": "0.1.0",
+  "description": "whale-girl 桌面伴侣：把 DSH Web GUI 内的鲸鱼娘宠物渲染到操作系统桌面",
+  "type": "module",
+  "main": "lib/index.mjs",
+  "bin": {
+    "whale-girl-desktop": "lib/index.mjs"
+  },
+  "scripts": {
+    "start": "node lib/index.mjs",
+    "start:headless": "node lib/index.mjs --headless",
+    "start:desktop": "electron .",
+    "test": "node --test \"test/**/*.test.mjs\""
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "electron": "^43.4.0"
+  }
+}

--- a/desktop/render/index.html
+++ b/desktop/render/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+  <title>whale-girl 桌面伴侣</title>
+  <style>
+    html, body {
+      margin: 0; padding: 0; overflow: hidden;
+      background: transparent !important;
+      width: 100vw; height: 100vh;
+      user-select: none; -webkit-user-select: none;
+    }
+    #stage {
+      position: fixed; inset: 0;
+      display: grid; place-items: center;
+      pointer-events: none; /* 视口层的点击穿透：只有 pet 本体可交互 */
+      touch-action: none;
+    }
+    canvas {
+      pointer-events: auto; /* 画布本身可点击/拖拽 */
+      cursor: grab;
+      image-rendering: pixelated;
+    }
+    canvas:active { cursor: grabbing; }
+    #bubble {
+      position: fixed; left: 50%; bottom: 96px;
+      transform: translateX(-50%);
+      background: rgba(24,28,38,.94); color: #E8EBF2;
+      font: 12px system-ui, sans-serif;
+      padding: 6px 10px; border-radius: 10px;
+      border: 1px solid rgba(255,255,255,.1);
+      white-space: nowrap; opacity: 0; pointer-events: none;
+      transition: opacity .18s ease-out;
+      z-index: 10;
+    }
+    #bubble.show { opacity: 1; }
+    #badge {
+      position: fixed; left: 50%; bottom: 4px; transform: translateX(-50%);
+      background: rgba(27,30,40,.9); color: #E8EBF2;
+      font: 10px/1.6 system-ui, sans-serif;
+      padding: 2px 8px; border-radius: 8px;
+      border: 1px solid rgba(255,255,255,.08);
+      white-space: nowrap; opacity: 0; pointer-events: none;
+      transition: opacity .18s ease-out; z-index: 10;
+    }
+    #badge.show { opacity: 1; }
+  </style>
+</head>
+<body>
+  <div id="stage">
+    <canvas id="pet" width="110" height="110"></canvas>
+  </div>
+  <div id="bubble"></div>
+  <div id="badge"></div>
+  <script src="./renderer.js"></script>
+</body>
+</html>

--- a/desktop/render/preload.cjs
+++ b/desktop/render/preload.cjs
@@ -1,0 +1,14 @@
+// Electron preload：暴露最小安全 IPC 面给 renderer（contextBridge）。
+// renderer 只拿得到 whaleGirl.*，无 Node 全局——保持 contextIsolation 语义。
+const { contextBridge, ipcRenderer } = require('electron')
+
+contextBridge.exposeInMainWorld('whaleGirl', {
+  getManifest: () => ipcRenderer.invoke('wg:manifest'),
+  getSheet: (characterId, sheet) => ipcRenderer.invoke('wg:sheet', { characterId, sheet }),
+  interact: (action) => ipcRenderer.send('wg:interact', action),
+  setHitarea: (rect) => ipcRenderer.send('wg:set-hitarea', rect),
+  dragWindow: (dx, dy) => ipcRenderer.send('wg:drag-window', { dx, dy }),
+  onAnim: (cb) => ipcRenderer.on('wg:anim', (_e, anim) => cb(anim)),
+  onSnapshot: (cb) => ipcRenderer.on('wg:snapshot', (_e, snap) => cb(snap)),
+  onReply: (cb) => ipcRenderer.on('wg:reply', (_e, reply) => cb(reply)),
+})

--- a/desktop/render/renderer.js
+++ b/desktop/render/renderer.js
@@ -74,14 +74,19 @@
     if (!(cfg.frames > 1)) return // 单帧状态由 CSS motion 表现（本端简化为静止）
 
     const step = () => {
-      const frameW = Math.floor(sheetCache.get(sheetKey(cfg.sheet)).w / cfg.frames)
+      const entry = sheetCache.get(sheetKey(cfg.sheet))
+      if (!entry) return // sheet 未就绪：跳过本帧（不裁切）
+      const frames = framesOf(cfg)
+      const frameW = Math.floor(entry.w / frames)
       ctx.clearRect(0, 0, canvas.width, canvas.height)
       ctx.save()
       ctx.translate(canvas.width / 2, canvas.height / 2)
       ctx.scale(flip, 1)
+      // 源矩形用 sprite 自身尺寸（entry.w/entry.h），不用 canvas 尺寸——
+      // canvas 缩放/尺寸变化不会产生源越界裁切（Copilot: 源高度 entry.h）。
       ctx.drawImage(
-        sheetCache.get(sheetKey(cfg.sheet)).img,
-        frame * frameW, 0, frameW, canvas.height,
+        entry.img,
+        frame * frameW, 0, frameW, entry.h,
         -canvas.width / 2, -canvas.height / 2, canvas.width, canvas.height,
       )
       ctx.restore()

--- a/desktop/render/renderer.js
+++ b/desktop/render/renderer.js
@@ -1,0 +1,308 @@
+// 渲染层（renderer）：Canvas 帧播放器 + 内容 bbox 点击穿透 + 气泡/角标。
+// 数据全部来自主进程 IPC（whaleGirl.*），零网络、零 CORS 面。
+// 帧播放对齐 whale-girl manifest（每状态一张横排 sheet：frames/fps/playback/motion）。
+
+(() => {
+  'use strict'
+
+  const wg = window.whaleGirl
+  if (!wg) { console.error('[renderer] 无 whaleGirl bridge（preload 未加载）'); return }
+
+  const canvas = document.getElementById('pet')
+  const ctx = canvas.getContext('2d', { willReadFrequently: false })
+  const bubble = document.getElementById('bubble')
+  const badge = document.getElementById('badge')
+
+  let manifest = null
+  let characterId = 'whale-girl'
+  const sheetCache = new Map() // `${characterId}/${sheet}` → { img, w, h }
+  let animState = 'idle'
+  let animCtx = {}
+  let frame = 0
+  let frameDir = 1
+  let lastFrameAt = 0
+  let blinkActive = false
+  let blinkAt = 0
+  let flip = 1
+  let facingAt = 0
+  let snapshot = null
+  let bubbleTimer = null
+
+  // ---- 画布尺寸（跟随 manifest stageSize；配置跟随 P1-4 预留） ----
+  const PET_BASE = 110
+  function applySize() {
+    const size = PET_BASE
+    canvas.width = size
+    canvas.height = size
+    canvas.style.width = `${size}px`
+    canvas.style.height = `${size}px`
+  }
+
+  // ---- 状态配置 ----
+  function stateCfg(name) {
+    return manifest?.characters?.[characterId]?.states?.[name] ?? null
+  }
+  function sheetKey(sheet) {
+    return `${characterId}/${sheet}`
+  }
+  // 安全帧数：单帧状态 frames=1 (frames>=1 恒真)；防损坏 manifest frames<=0 除零（reviewer 建议）。
+  function framesOf(cfg) {
+    const n = cfg?.frames
+    return typeof n === 'number' && n > 0 ? Math.floor(n) : 1
+  }
+  async function ensureSheet(cfg) {
+    if (!cfg || !cfg.sheet) return null
+    const key = sheetKey(cfg.sheet)
+    if (sheetCache.has(key)) return sheetCache.get(key)
+    const dataURL = await wg.getSheet(characterId, cfg.sheet)
+    if (!dataURL) { sheetCache.set(key, null); return null }
+    const img = new Image()
+    await new Promise((resolve, reject) => {
+      img.onload = resolve
+      img.onerror = reject
+      img.src = dataURL
+    })
+    const entry = { img, w: img.naturalWidth, h: img.naturalHeight }
+    sheetCache.set(key, entry)
+    return entry
+  }
+
+  // ---- 帧推进（playback 对齐 whale-girl：loop/pingpong/once/blink） ----
+  function tickFrame(now) {
+    const cfg = stateCfg(animState)
+    if (!cfg || !cfg.sheet) return
+    if (!(cfg.frames > 1)) return // 单帧状态由 CSS motion 表现（本端简化为静止）
+
+    const step = () => {
+      const frameW = Math.floor(sheetCache.get(sheetKey(cfg.sheet)).w / cfg.frames)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.save()
+      ctx.translate(canvas.width / 2, canvas.height / 2)
+      ctx.scale(flip, 1)
+      ctx.drawImage(
+        sheetCache.get(sheetKey(cfg.sheet)).img,
+        frame * frameW, 0, frameW, canvas.height,
+        -canvas.width / 2, -canvas.height / 2, canvas.width, canvas.height,
+      )
+      ctx.restore()
+    }
+
+    if (cfg.playback === 'blink') {
+      if (blinkActive) {
+        if (now - lastFrameAt >= 1000 / cfg.fps) {
+          lastFrameAt = now
+          frame += 1
+          if (frame >= cfg.frames) { frame = 0; blinkActive = false; blinkAt = now + rand(3000, 9000) }
+          step()
+        }
+      } else {
+        if (frame !== 0) { frame = 0; step() }
+        if (blinkAt === 0) blinkAt = now + rand(3000, 9000)
+        if (now >= blinkAt) blinkActive = true
+      }
+      return
+    }
+
+    if (now - lastFrameAt >= 1000 / (cfg.fps || 2)) {
+      lastFrameAt = now
+      frame += frameDir
+      if (cfg.playback === 'pingpong') {
+        if (frame >= cfg.frames - 1 || frame <= 0) frameDir *= -1
+        frame = Math.max(0, Math.min(cfg.frames - 1, frame))
+      } else if (frame >= cfg.frames) {
+        if (cfg.playback === 'loop') frame = 0
+        else frame = cfg.frames - 1 // once：保持末帧
+      }
+      step()
+    } else if (!sheetCache.get(sheetKey(cfg.sheet))?.rendered) {
+      step()
+    }
+  }
+
+  // ---- 随机穿梭/转身（对齐 whale-girl：静态态偶尔转身） ----
+  function tickFacing(now, cfg) {
+    if (animState === 'idle' || animState === 'think' || animState === 'wait') {
+      if (facingAt === 0) facingAt = now + rand(10000, 25000)
+      if (now >= facingAt) {
+        flip = -flip
+        facingAt = now + rand(10000, 25000)
+        // 立即重绘（否则等待下一帧推进）
+        const entry = sheetCache.get(sheetKey(cfg.sheet))
+        if (entry?.rendered) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height)
+          ctx.save(); ctx.translate(canvas.width/2, canvas.height/2); ctx.scale(flip, 1)
+          const frameW = Math.floor(entry.w / framesOf(cfg))
+          ctx.drawImage(entry.img, frame * frameW, 0, frameW, entry.h, -canvas.width/2, -canvas.height/2, canvas.width, canvas.height)
+          ctx.restore()
+        }
+      }
+    } else if (facingAt !== 0) {
+      facingAt = 0
+    }
+  }
+
+  function rand(min, max) {
+    return min + Math.random() * (max - min)
+  }
+
+  // ---- 切换动画状态 ----
+  let switchingState = false
+  async function switchAnim(next) {
+    const name = next?.name || 'idle'
+    if (name === animState) {
+      animCtx = next?.context ?? animCtx
+      return
+    }
+    animState = name
+    animCtx = next?.context ?? animCtx
+    frame = 0
+    frameDir = 1
+    blinkActive = false
+    blinkAt = 0
+    lastFrameAt = 0
+    applySize()
+    const cfg = stateCfg(name)
+    if (!cfg) { drawPlaceholder(); return }
+    await ensureSheet(cfg)
+    drawFrame()
+    reportHitarea()
+  }
+
+  function drawPlaceholder() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.save()
+    ctx.translate(canvas.width/2, canvas.height/2)
+    ctx.font = `${Math.floor(canvas.width * 0.4)}px system-ui`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText('🐳', 0, 0)
+    ctx.restore()
+  }
+
+  function drawFrame() {
+    const cfg = stateCfg(animState)
+    if (!cfg) return drawPlaceholder()
+    const entry = sheetCache.get(sheetKey(cfg.sheet))
+    if (!entry) return drawPlaceholder()
+    const frameW = Math.floor(entry.w / framesOf(cfg))
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.save()
+    ctx.translate(canvas.width / 2, canvas.height / 2)
+    ctx.scale(flip, 1)
+    ctx.drawImage(entry.img, frame * frameW, 0, frameW, entry.h,
+      -canvas.width / 2, -canvas.height / 2, canvas.width, canvas.height)
+    ctx.restore()
+    entry.rendered = true
+  }
+
+  // ---- 内容 bbox → 点击穿透（宠物本体可交互，透明区点击穿透） ----
+  function reportHitarea() {
+    const cfg = stateCfg(animState)
+    const entry = sheetCache.get(sheetKey(cfg?.sheet))
+    if (!entry) { wg.setHitarea(null); return }
+    const frameW = Math.floor(entry.w / framesOf(cfg))
+    // 读当前帧 Alpha（只在状态切换/变换后读一次，小图可接受）
+    const off = document.createElement('canvas')
+    off.width = frameW; off.height = entry.h
+    const octx = off.getContext('2d')
+    octx.drawImage(entry.img, frame * frameW, 0, frameW, entry.h, 0, 0, frameW, entry.h)
+    const data = octx.getImageData(0, 0, frameW, entry.h).data
+    let minX = Infinity, minY = Infinity, maxX = -1, maxY = -1
+    for (let y = 0; y < entry.h; y++) {
+      for (let x = 0; x < frameW; x++) {
+        if (data[(y * frameW + x) * 4 + 3] > 24) {
+          if (x < minX) minX = x
+          if (x > maxX) maxX = x
+          if (y < minY) minY = y
+          if (y > maxY) maxY = y
+        }
+      }
+    }
+    if (maxX < 0) { wg.setHitarea(null); return }
+    // 归一化到画布坐标（canvas.width / frameW 是缩放比）
+    const scaleX = canvas.width / frameW
+    const scaleY = canvas.height / entry.h
+    wg.setHitarea({
+      x: minX * scaleX, y: minY * scaleY,
+      w: (maxX - minX + 1) * scaleX, h: (maxY - minY + 1) * scaleY,
+    })
+  }
+
+  // ---- 主循环（60fps 够了；帧推进按 fps） ----
+  function loop(now) {
+    const cfg = stateCfg(animState)
+    if (cfg) {
+      tickFrame(now)
+      tickFacing(now, cfg)
+    } else if (animState) {
+      drawPlaceholder()
+    }
+    requestAnimationFrame(loop)
+  }
+
+  // ---- 气泡 / 角标 ----
+  function showBubble(text) {
+    bubble.textContent = text
+    bubble.classList.add('show')
+    clearTimeout(bubbleTimer)
+    bubbleTimer = setTimeout(() => bubble.classList.remove('show'), 2500)
+  }
+  function renderBadge() {
+    if (!snapshot) { badge.classList.remove('show'); return }
+    const p = snapshot.pet
+    const titles = (p?.titles?.length ?? 0)
+    badge.textContent = `Lv.${p?.level ?? 1} · ${p?.stats?.tasksDone ?? 0} 任务` + (titles ? ` · ${titles} 称号` : '')
+    if ((snapshot?.activity?.sessionThink ?? false)) badge.textContent += ' · 思考中'
+    badge.classList.add('show')
+  }
+
+  // ---- 交互：点击 / 拖拽 ----
+  let dragStart = null
+  canvas.addEventListener('pointerdown', (e) => {
+    dragStart = { x: e.screenX, y: e.screenY, moved: false }
+    canvas.setPointerCapture(e.pointerId)
+  })
+  canvas.addEventListener('pointermove', (e) => {
+    if (!dragStart) return
+    const dx = e.screenX - dragStart.x
+    const dy = e.screenY - dragStart.y
+    if (!dragStart.moved && Math.hypot(dx, dy) > 6) dragStart.moved = true
+    if (dragStart.moved) {
+      wg.dragWindow(dx, dy) // 主进程移动窗口（基于绝对值更稳：传由主进程记录起点）
+      dragStart.x = e.screenX
+      dragStart.y = e.screenY
+    }
+  })
+  canvas.addEventListener('pointerup', (e) => {
+    if (dragStart && !dragStart.moved) {
+      // 点击 = 互动：轮换 feed/play
+      const action = (sessionStorage.getItem('wg:lastAction') === 'feed') ? 'play' : 'feed'
+      sessionStorage.setItem('wg:lastAction', action)
+      wg.interact(action)
+    }
+    dragStart = null
+  })
+
+  // ---- IPC 订阅 ----
+  wg.onAnim(async (anim) => {
+    await switchAnim(anim)
+  })
+  wg.onSnapshot((snap) => {
+    snapshot = snap
+    renderBadge()
+  })
+  wg.onReply((reply) => {
+    if (reply) showBubble(reply)
+  })
+
+  // ---- 启动 ----
+  ;(async () => {
+    manifest = await wg.getManifest()
+    // 默认角色
+    if (manifest?.default) characterId = manifest.default
+    applySize()
+    await switchAnim({ name: 'idle', context: {} })
+    requestAnimationFrame(loop)
+    renderBadge()
+  })()
+})()

--- a/desktop/test/contract.test.mjs
+++ b/desktop/test/contract.test.mjs
@@ -18,6 +18,23 @@ import { STATE_NAMES } from '../lib/client/state-names.mjs'
 
 const BASE = loadConfig().baseURL
 
+// live 套件依赖真实 DSH web。探活一次（缓存）来给 describe 动态 skip：
+// 服务不可达 → 套件整体 skip（CI / 无服务环境不误判失败）；WG_LIVE=1 则强制要求真跑。
+let _liveProbe = null
+async function liveReachable() {
+  if (_liveProbe === null) {
+    try {
+      await fetch(`${BASE}/whale-girl/state`, { cache: 'no-store' })
+      _liveProbe = true
+    } catch {
+      _liveProbe = false
+    }
+  }
+  return _liveProbe
+}
+const liveAvailable = await liveReachable()
+const forceLive = process.env.WG_LIVE === '1'
+
 // ---------- 状态机纯函数 ----------
 
 describe('state machine (pickState)', () => {
@@ -182,8 +199,9 @@ describe('SSE client', () => {
 })
 
 // ---------- 端到端契约（需 DSH web 运行中） ----------
+// live 套件依赖真实 DSH web。服务不可达时整组 skip（CI 不误判）；WG_LIVE=1 强制真跑（不可达即失败）。
 
-describe('whale-girl contract (live)', { skip: false }, () => {
+describe('whale-girl contract (live)', { skip: !liveAvailable && !forceLive }, () => {
   let client
   let companion
 

--- a/desktop/test/contract.test.mjs
+++ b/desktop/test/contract.test.mjs
@@ -1,0 +1,281 @@
+// whale-girl-desktop 契约测试：
+// 1. 纯函数单测：状态机（state.mjs / scheduler.mjs / behaviors.mjs）确定性映射
+// 2. 端到端契约测试：连真实 DSH web（/state /config /presence /interact /assets）
+//    —— 验证本端点到 whale-girl 的消费契约与 DESIGN.md §3 一致
+//
+// 运行：npm test（node --test test/）。
+// 端到端部分需要 DSH web 在 http://127.0.0.1:3080（WHALE_GIRL_BASE_URL 可覆盖）。
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadConfig } from '../lib/src/config.mjs'
+import { createClient } from '../lib/client/http.mjs'
+import { pickState, pickAnimation } from '../lib/client/state.mjs'
+import { createScheduler, stepScheduler, applyInteraction } from '../lib/client/scheduler.mjs'
+import { nextWorkingRhythm } from '../lib/client/behaviors.mjs'
+import { createSSEClient } from '../lib/client/events.mjs'
+import { STATE_NAMES } from '../lib/client/state-names.mjs'
+
+const BASE = loadConfig().baseURL
+
+// ---------- 状态机纯函数 ----------
+
+describe('state machine (pickState)', () => {
+  const now = 1_000_000
+
+  it('idle 为兜底', () => {
+    assert.equal(pickState({ activity: { name: 'idle', until: 0 }, now }), 'idle')
+  })
+
+  it('activity burst 优先（celebrate/error/welcome within until）', () => {
+    for (const name of ['celebrate', 'error', 'disappointed', 'welcome']) {
+      assert.equal(
+        pickState({ activity: { name, until: now + 1000 }, now }),
+        name,
+        `burst ${name} 应优先`,
+      )
+    }
+  })
+
+  it('burst 过期后回到底层状态', () => {
+    assert.equal(
+      pickState({ activity: { name: 'celebrate', until: now - 1 }, now, sessionThink: true }),
+      'think',
+    )
+  })
+
+  it('sessionWait → wait', () => {
+    assert.equal(
+      pickState({ activity: { name: 'idle', until: 0 }, now, sessionWait: true }),
+      'wait',
+    )
+  })
+
+  it('sessionThink → think（无插曲时）', () => {
+    assert.equal(
+      pickState({ activity: { name: 'idle', until: 0 }, now, sessionThink: true }),
+      'think',
+    )
+  })
+
+  it('turnCompletedUntil 窗口 → celebrate（低于事件 burst）', () => {
+    assert.equal(
+      pickState({ activity: { name: 'idle', until: 0 }, now, celebrateUntil: now + 1000 }),
+      'celebrate',
+    )
+    // 事件 burst 覆盖回合完成庆祝
+    assert.equal(
+      pickState({ activity: { name: 'error', until: now + 500 }, now, celebrateUntil: now + 1000 }),
+      'error',
+    )
+  })
+
+  it('sleep 在 idle 且空闲超时后', () => {
+    assert.equal(pickState({ activity: { name: 'idle', until: 0 }, now, sleep: true }), 'sleep')
+  })
+
+  it('transient eat/play/wake', () => {
+    assert.equal(pickState({ activity: { name: 'idle', until: 0 }, now, transient: 'eat' }), 'eat')
+    assert.equal(pickState({ activity: { name: 'idle', until: 0 }, now, transient: 'play' }), 'play')
+    assert.equal(pickState({ activity: { name: 'idle', until: 0 }, now, transient: 'wake' }), 'wake')
+  })
+})
+
+describe('working rhythm (nextWorkingRhythm)', () => {
+  const now = 5_000_000
+  it('会话不活跃 → 关闭', () => {
+    assert.deepEqual(nextWorkingRhythm({ now, sessionThink: false }), { active: false, until: 0 })
+  })
+  it('思考期非工作 → 进入 working，until 在未来', () => {
+    const r = nextWorkingRhythm({ now, sessionThink: true, working: { active: false, until: 0 } })
+    assert.equal(r.active, true)
+    assert.ok(r.until > now)
+  })
+  it('工作期结束 → 回 think', () => {
+    const r = nextWorkingRhythm({ now, sessionThink: true, working: { active: true, until: now } })
+    assert.equal(r.active, false)
+    assert.ok(r.until > now)
+  })
+})
+
+describe('scheduler (stepScheduler + applyInteraction)', () => {
+  const now = 2_000_000
+  it('空闲开始计时，超 sleepAfterMs 入睡', () => {
+    const s = createScheduler({ sleepAfterMs: 60_000 })
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now })
+    assert.equal(s.sleeping, false, '刚 idle 不立刻睡')
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now: now + 61_000 })
+    assert.equal(s.sleeping, true, '空闲超 60s 入睡')
+  })
+
+  it('会话活跃重置空闲起点（不因工作期误判睡眠）', () => {
+    const s = createScheduler()
+    // 先 idle 60s（睡），然后 working
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now })
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now: now + 61_000 })
+    assert.equal(s.sleeping, true)
+    stepScheduler(s, { snapshot: { activity: { name: 'working', until: now + 1000 } }, now: now + 62_000 })
+    assert.equal(s.sleeping, false, '工作态下不判睡')
+    assert.equal(s.idleSince, 0, '活跃重置空闲起点')
+  })
+
+  it('interact 后播 eat/play + 喜悦，睡眠被唤醒', () => {
+    const s = createScheduler()
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now })
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now: now + 61_000 })
+    assert.equal(s.sleeping, true)
+    applyInteraction(s, 'feed')
+    assert.equal(s.transient, 'eat')
+    assert.equal(s.sleeping, false)
+    applyInteraction(s, 'play')
+    assert.equal(s.transient, 'play')
+  })
+
+  it('瞬发播完（超时）回 joy，再跌落', () => {
+    const s = createScheduler()
+    applyInteraction(s, 'feed')
+    assert.equal(s.transient, 'eat')
+    stepScheduler(s, { snapshot: { activity: { name: 'idle', until: 0 } }, now: Date.now() + 2000 })
+    assert.equal(s.transient, null)
+    assert.ok(s.joyUntil > 0, '互动后进入喜悦窗口')
+  })
+})
+
+describe('state names', () => {
+  it('15 状态权威集合（与 whale-girl 一致）', () => {
+    assert.deepEqual([...STATE_NAMES], [
+      'idle', 'working', 'celebrate', 'error', 'disappointed', 'joy', 'eat', 'play',
+      'drag', 'walk', 'sleep', 'wake', 'welcome', 'think', 'wait',
+    ])
+  })
+})
+
+// ---------- SSE 客户端 ----------
+
+describe('SSE client', () => {
+  it('解析 data 事件并触发回调（本地 http server 模拟）', async () => {
+    const http = await import('node:http')
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' })
+      res.write('retry: 1000\n\n')
+      res.write('data: {"type":"event"}\n\n')
+      setTimeout(() => {
+        res.write(': ping\n\n')
+        res.end()
+      }, 50)
+    })
+    await new Promise((r) => server.listen(0, '127.0.0.1', r))
+    const port = server.address().port
+
+    const got = []
+    const sse = createSSEClient(`http://127.0.0.1:${port}/events`)
+    await new Promise((resolve) => {
+      sse.events.on('event', (payload) => {
+        got.push(payload)
+        if (got.length >= 1) resolve()
+      })
+    })
+    sse.close()
+    await new Promise((r) => server.close(r))
+    assert.deepEqual(got, ['{"type":"event"}'])
+  })
+})
+
+// ---------- 端到端契约（需 DSH web 运行中） ----------
+
+describe('whale-girl contract (live)', { skip: false }, () => {
+  let client
+  let companion
+
+  before(async () => {
+    client = createClient({ baseURL: BASE })
+  })
+
+  it('GET /state 符合契约形状', async () => {
+    const body = await client.getState()
+    assert.equal(typeof body.apiVersion, 'number')
+    assert.equal(typeof body.pet?.level, 'number')
+    assert.equal(typeof body.pet?.xp, 'number')
+    assert.equal(typeof body.pet?.stats?.tasksDone, 'number')
+    assert.equal(typeof body.activity?.name, 'string')
+    assert.ok(['idle', 'working', 'welcome', 'celebrate', 'error', 'disappointed'].includes(body.activity.name))
+    assert.equal(typeof body.configRevision, 'number')
+    assert.equal(typeof body.companionOnline, 'boolean')
+  })
+
+  it('GET /config 返回 { config, revision }', async () => {
+    const body = await client.getConfig()
+    assert.equal(typeof body.revision, 'number')
+    assert.equal(typeof body.config?.enabled, 'boolean')
+    assert.equal(typeof body.config?.size, 'number')
+  })
+
+  it('GET /assets/manifest.json 含 whale-girl 角色与 15 状态', async () => {
+    const m = await client.getManifest()
+    const states = m?.characters?.['whale-girl']?.states
+    assert.ok(states, 'manifest 应有 whale-girl 角色')
+    const keys = Object.keys(states)
+    for (const s of STATE_NAMES) assert.ok(keys.includes(s), `缺少状态 ${s}`)
+  })
+
+  it('POST /presence {online:true} → 在线；{online:false} → 下线', async () => {
+    const up = await client.setPresence(true)
+    assert.equal(up.online, true)
+    // 状态里 companionOnline 应同步
+    const st = await client.getState()
+    assert.equal(st.companionOnline, true)
+    const down = await client.setPresence(false)
+    assert.equal(down.online, false)
+    const st2 = await client.getState()
+    assert.equal(st2.companionOnline, false)
+  })
+
+  it('POST /interact feed/play → { pet, reply }', async () => {
+    const r = await client.interact('feed')
+    assert.equal(typeof r.pet?.level, 'number')
+    assert.equal(typeof r.reply, 'string')
+    const r2 = await client.interact('play')
+    assert.equal(typeof r2.reply, 'string')
+  })
+
+  it('GET /assets/characters/whale-girl/idle.png → HTTP 200 image/png', async () => {
+    const res = await fetch(`${client.url('/assets/characters/whale-girl/idle.png')}`)
+    assert.equal(res.status, 200)
+    assert.match(res.headers.get('content-type') ?? '', /image\/png/)
+    const buf = await res.arrayBuffer()
+    assert.ok(buf.byteLength > 1000)
+  })
+
+  it('companion 端到端：createCompanion 心跳 + 拉 state + stop 下线', async () => {
+    const { createCompanion } = await import('../lib/client/companion.mjs')
+    companion = await createCompanion({ ...loadConfig(), autoPresence: true, eventsEnabled: true }, {
+      onAnimation: () => {},
+      onSnapshot: () => {},
+      onReply: () => {},
+    })
+    assert.ok(companion.getState()?.pet, 'companion 应已拉到 state')
+    const st = await client.getState()
+    assert.equal(st.companionOnline, true, 'companion 启动后应在场')
+    await companion.stop()
+    const st2 = await client.getState()
+    assert.equal(st2.companionOnline, false, 'companion stop 后应下线')
+  })
+
+  after(async () => {
+    if (companion) await companion.stop()
+  })
+})
+
+describe('config load', () => {
+  it('默认 BaseURL', () => {
+    const c = loadConfig({ env: {}, argv: [] })
+    assert.equal(c.baseURL, 'http://127.0.0.1:3080')
+    assert.equal(c.pollMs, 3000)
+    assert.equal(c.heartbeatMs, 15000)
+  })
+  it('CLI 覆盖', () => {
+    const c = loadConfig({ env: {}, argv: ['node', 'lib/index.mjs', '--headless', '--poll-ms=5000'] })
+    assert.equal(c.renderEnabled, false)
+    assert.equal(c.pollMs, 5000)
+  })
+})


### PR DESCRIPTION
# PR: 新增 whale-girl 桌面伴侣（desktop/ 独立应用）

## Summary

新增 **`desktop/`** 独立应用：把 whale-girl 的鲸鱼娘化身渲染到操作系统桌面（透明置顶窗），
作为外部 HTTP 消费者实时消费本插件的既有端点（`/state`、`/events` SSE、`/presence`、
`/interact`、`/config`、`/assets`）。**不改动 whale-girl 本体任何端点或账本语义。**

配合本插件已支持的 `companionOnline` presence 契约：桌面伴侣在线时网页端隐藏自己的宠物，
避免"双宠物"。

## 功能

- **P0 核心**
  - presence 心跳：每 15s `POST /presence {online:true}`（TTL 45s，崩溃 45s 自动过期回网页端）
  - 状态轮询：每 3s `GET /state`，解析 pet + activity
  - 事件即时刷新：`EventSource /events`，事件到即 re-poll `/state`
  - 桌面渲染：Electron 透明置顶窗 + Canvas 帧播放（复用 `lib/assets/manifest.json` 帧布局，
    经 IPC 把 manifest/sprite 从主进程 dataURL 喂给 renderer，renderer 零网络、无 CORS 面）
  - 退出清理：关窗/退出 → `{online:false}` 显式下线，网页宠物立即恢复
- **P1 体验**
  - 点击互动：点宠物 → `feed`/`play` 轮换，气泡回话
  - 资历角标：`Lv.${level} · ${tasksDone} 任务 · ${称号数} · 思考中`
  - 本地状态机：睡眠/游走/working 插曲/互动瞬发（对齐 `lib/client/logic.mjs` 的 `pickState`）

## 目录结构

```
desktop/
├─ package.json          # ESM, main: lib/index.mjs（独立应用，不并入插件 bundles/files）
├─ lib/
│  ├─ index.mjs          # 入口：headless / Electron 分流
│  ├─ src/config.mjs     # 本地运行参数（BaseURL、pollMs、heartbeatMs）
│  └─ client/            # 核心引擎（纯 Node，零第三方依赖）
│     ├─ companion.mjs   # 心跳+轮询+SSE+调度+互动
│     ├─ http.mjs        # fetch 封装
│     ├─ events.mjs      # SSE 客户端（fetch 流式，断线重连）
│     ├─ scheduler.mjs   # 睡眠/游走/working 插曲/interact 瞬发
│     ├─ state.mjs       # 状态机（对齐 whale-girl pickState）
│     └─ behaviors.mjs   # working 节奏/睡醒/醒觉纯函数
├─ render/               # Electron 渲染层
│  ├─ index.html / preload.cjs / renderer.js
│  └─ window.mjs（在 lib/）
├─ BUILD-RUN.md          # 构建/运行/测试/踩坑
├─ DESIGN.md             # 设计方案
└─ test/contract.test.mjs # 状态机/调度/SSE + 端到端契约测试
```

> 说明：`desktop/` 是**独立应用**，不在 `package.json` 的 `bundles/files` 白名单内——
> 它通过已公开 HTTP 端点消费，对插件本体零侵入，`dsh plugin` 安装流程不受影响。

## 用法

```sh
cd desktop
npm install        # 依赖仅 electron（devDependency）
npm run start:desktop   # Electron 桌面渲染（透明置顶宠物）
npm run start:headless  # 无窗核心（心跳+状态+SSE）
npm test                # 26 用例（含连真实 DSH /state 端到端契约）
```

Electron 二进制在国内网络下载超时时，用 `ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ node node_modules/electron/install.js` 补下载（记入 BUILD-RUN.md）。

## 验证结果

1. **`npm test` 26/26 全绿**（在 `desktop/` 下独立运行）：状态机确定性映射、调度器、
   SSE 解析/重连（本地模拟）+ **连真实 DSH(127.0.0.1:3080) 端到端契约**：
   `/state` 形状、`/config`、`/manifest`（15 状态齐全）、`/presence` 上下线同步、
   `/interact`、sprite HTTP 200、`createCompanion` 全链路（心跳上线 → `stop` 下线）。
2. **退出握手**：`companion.stop()` 后 `GET /state.companionOnline === false`（实测）。
   崩溃兜底：心跳停 → TTL 45s 过期网页自动恢复。
3. **桌面可视化**：Electron 透明置顶窗正常创建，`companionOnline=true`（网页宠物隐藏），
   屏幕截屏经视觉模型确认鲸鱼娘在右下角渲染可见，角标显示 Lv/任务数/称号。
4. **CSRF 面**：本地 HTTP 调用不带 Origin/Sec-Fetch-Site → `isCrossOrigin` 判定同源，
   `/presence`/`/interact` 放行（端到端测试覆盖）。

## 关键实现说明 / 踩坑（详见 desktop/BUILD-RUN.md）

- **Electron ESM main 顶层 await 陷阱**：入口在模块顶层 `await runDesktop()`（内含
  `await app.whenReady()`）会阻塞事件循环致 `ready` 永不触发；改 `process.nextTick`
  fire-and-forget 后正常。
- **确定性时间**：状态表谓词用注入的 `c.now` 而非 `Date.now()`（保证测试确定性）。
- **`/presence` 与 `/interact` 超时**：退出下线带 2s AbortSignal 超时，防 DSH 瞬时不可达挂死。
- sprite 帧数除零防护（`framesOf` 兜底 1）。

## 决策记录

按仓库约定新增 `decisions/implemented/feature/YYYY-MM-DD-desktop-companion.md`（桌面伴侣作为
独立外部消费者的架构决策）。

## 测试 / 门禁

- 本 PR 只**新增** `desktop/` 与一份决策记录；不改 `lib/`、`lib/client.js`、`lib/assets/`、
  `tests/`、`scripts/gates/`。仓库既有 `node scripts/gates/run.mjs` 不受影响。
- `cd desktop && npm test` 26/26 全绿（desktop 自带测试，独立于仓库 gates）。

---

（本 PR 由 AgentTeams 协作完成：researcher 设计 t1 → engineer 实现 t3 → reviewer 审核 t4 通过后提交。）
